### PR TITLE
Translated german strings

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2,19 +2,19 @@
     <string name="app_name">Schlichter SMS Messenger</string>
     <string name="app_launcher_name">SMS Messenger</string>
     <string name="type_a_message">Schreibe eine Nachricht…</string>
-    <string name="message_not_sent_short">Message not sent</string>
-    <string name="message_not_sent_touch_retry">Not sent. Touch to retry.</string>
-    <string name="message_sending_error">Your message to \'%s\' has not been sent</string>
+    <string name="message_not_sent_short">Nachricht nicht versendet.</string>
+    <string name="message_not_sent_touch_retry">Nachricht nicht versendet. Berühre, um es erneut zu versuchen.</string>
+    <string name="message_sending_error">Deine Nachricht am \'%s\' wurde nicht gesendet.</string>
     <string name="add_person">Person hinzufügen</string>
     <string name="attachment">Anhang</string>
     <string name="no_conversations_found">Keine gespeicherten Chats gefunden</string>
     <string name="start_conversation">Neuen Chat beginnen</string>
     <string name="reply">Antworten</string>
-    <string name="show_character_counter">Show a character counter at writing messages</string>
-    <string name="loading_messages">Loading messages…</string>
-    <string name="no_reply_support">Sender doesn\'t support replies</string>
-    <string name="draft">Draft</string>
-    <string name="sending">Sending…</string>
+    <string name="show_character_counter">Zeige einen Zeichenzähler während dem Schreiben von Nachrichten.</string>
+    <string name="loading_messages">Lade Nachrichten…</string>
+    <string name="no_reply_support">Der Absender unterstützt keine Antworten.</string>
+    <string name="draft">Entwurf</string>
+    <string name="sending">Sende…</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Neuer Chat</string>
@@ -49,21 +49,21 @@
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
-    <string name="app_title">Simple SMS Messenger - Manage messages easily</string>
+    <string name="app_title">Simple SMS Messenger-Nachrichten simple verwalten</string>
     <!-- Short description has to have max 80 characters -->
-    <string name="app_short_description">An easy and quick way of managing SMS and MMS messages without ads.</string>
+    <string name="app_short_description">Eine einfache und schnelle Art SMS & MMS ohne Werbung zu verwalten.</string>
     <string name="app_long_description">
-        A great way to stay in touch with your relatives, by sending both SMS and MMS messages. The app properly handles group messaging too, just like blocking numbers from Android 7+.
+        In tolle Möglichkeit mit deinen Verwandten in Kontakt zu bleiben, indem sowohl SMS als auch MMS Nachrichten gesendet werden. Die App handhabt auch Gruppennachrichten gut, genauso wie das Blockieren von Nummern ab Android 7+.
 
-        It offers many date formats to choose from, to make you feel comfortable at using it. You can toggle between 12 and 24 hours time format too.
+        Damit die Nutzung sich vertrauter und komfortabler anfühlt, kannst du das Datumsformat in verschiedenen Arten anpassen. Zudem kannst du zwischen 12 und 24 Stunden Format auswählen.
+      
+        Im Vergleich zur Konkurrenz ist die Appgröße sehr klein, wodurch es sehr schnell heruntergeladen ist.
 
-        It has a really tiny app size compared to the competition, making it really fast to download.
+        Es kommt standardmäßig mit einem material design und Dunkelmodus, was für ein großartiges Nutzererlebnis und leichte Nutzbarkeit sorgt. Da es keine Internetverbindung verwendet, bietet diese App mehr Datenschutz, Sicherheit und Stabilität als andere Apps.
 
-        It comes with material design and dark theme by default, provides great user experience for easy usage. The lack of internet access gives you more privacy, security and stability than other apps.
+        Beinhaltet keine Werbung oder unnötige Berechtigungen. Es ist komplett opensource, und bietet anpassbare Farben.
 
-        Contains no ads or unnecessary permissions. It is fully opensource, provides customizable colors.
-
-        <b>Check out the full suite of Simple Tools here:</b>
+        <b>Entdecke alle Simple Tools hier:</b>
         https://www.simplemobiletools.com
 
         <b>Facebook:</b>


### PR DESCRIPTION
In line 52 "Simple SMS Messenger - Nachrichten einfach verwalten" would be nicer, but has more than 50 characters.
So I edited it to "simple" which is also correct and delete 2 spaces. Not the best for styling though...