### PR TITLE
Added preference to enable/disable links in messages

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/SettingsActivity.kt
@@ -13,7 +13,8 @@ import com.simplemobiletools.commons.helpers.*
 import com.simplemobiletools.commons.models.RadioItem
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.extensions.config
-import com.simplemobiletools.smsmessenger.helpers.refreshMessages
+import com.simplemobiletools.smsmessenger.extensions.getAllowLinksText
+import com.simplemobiletools.smsmessenger.helpers.*
 import kotlinx.android.synthetic.main.activity_settings.*
 import java.util.*
 
@@ -35,6 +36,7 @@ class SettingsActivity : SimpleActivity() {
         setupManageBlockedNumbers()
         setupChangeDateTimeFormat()
         setupFontSize()
+        setupAllowLinks()
         setupShowCharacterCounter()
         updateTextColors(settings_scrollview)
 
@@ -113,6 +115,22 @@ class SettingsActivity : SimpleActivity() {
             RadioGroupDialog(this@SettingsActivity, items, config.fontSize) {
                 config.fontSize = it as Int
                 settings_font_size.text = getFontSizeText()
+            }
+        }
+    }
+    
+    private fun setupAllowLinks() {
+        settings_allow_links.text = getAllowLinksText()
+        settings_allow_links_holder.setOnClickListener {
+            val items = arrayListOf(
+                RadioItem(ALLOW_LINKS_SENT, getString(R.string.allow_links_in_sent)),
+                RadioItem(ALLOW_LINKS_RECEIVED, getString(R.string.allow_links_in_received)),
+                RadioItem(ALLOW_LINKS_ALWAYS, getString(R.string.allow_links_always)),
+                RadioItem(ALLOW_LINKS_NEVER, getString(R.string.allow_links_never)))
+
+            RadioGroupDialog(this@SettingsActivity, items, config.allowLinks) {
+                config.allowLinks = it as Int
+                settings_allow_links.text = getAllowLinksText()
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -32,6 +32,7 @@ import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
 import com.simplemobiletools.smsmessenger.dialogs.SelectTextDialog
 import com.simplemobiletools.smsmessenger.extensions.deleteMessage
+import com.simplemobiletools.smsmessenger.extensions.config
 import com.simplemobiletools.smsmessenger.helpers.*
 import com.simplemobiletools.smsmessenger.models.*
 import kotlinx.android.synthetic.main.item_attachment_image.view.*
@@ -215,6 +216,17 @@ class ThreadAdapter(
         view.apply {
             thread_message_holder.isSelected = selectedKeys.contains(message.hashCode())
             thread_message_body.apply {
+		if (message.isReceivedMessage()) {
+		  if (activity.config.allowLinks != ALLOW_LINKS_RECEIVED && 
+		      activity.config.allowLinks != ALLOW_LINKS_ALWAYS) {
+		     setAutoLinkMask(0)
+		  }
+		} else {
+		  if ((activity.config.allowLinks != ALLOW_LINKS_SENT) && 
+		      (activity.config.allowLinks != ALLOW_LINKS_ALWAYS)) {
+		     setAutoLinkMask(0)
+		  }
+		}
                 text = message.body
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, fontSize)
             }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -51,6 +51,14 @@ val Context.messageAttachmentsDB: MessageAttachmentsDao get() = getMessagessDB()
 
 val Context.messagesDB: MessagesDao get() = getMessagessDB().MessagesDao()
 
+fun Context.getAllowLinksText() = getString(when (config.allowLinks) {
+    ALLOW_LINKS_SENT -> R.string.allow_links_in_sent
+    ALLOW_LINKS_RECEIVED -> R.string.allow_links_in_received
+    ALLOW_LINKS_ALWAYS -> R.string.allow_links_always
+    ALLOW_LINKS_NEVER -> R.string.allow_links_never
+    else -> R.string.allow_links_in_sent
+})
+
 fun Context.getMessages(threadId: Long): ArrayList<Message> {
     val uri = Sms.CONTENT_URI
     val projection = arrayOf(

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Config.kt
@@ -17,4 +17,9 @@ class Config(context: Context) : BaseConfig(context) {
     var showCharacterCounter: Boolean
         get() = prefs.getBoolean(SHOW_CHARACTER_COUNTER, false)
         set(showCharacterCounter) = prefs.edit().putBoolean(SHOW_CHARACTER_COUNTER, showCharacterCounter).apply()
+   
+    // We set a default value of 1 which is ALLOW_LINKS_SENT 
+    var allowLinks: Int
+        get() = prefs.getInt(ALLOW_LINKS, ALLOW_LINKS_SENT)
+        set(allowLinks) = prefs.edit().putInt(ALLOW_LINKS, allowLinks).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Constants.kt
@@ -26,6 +26,13 @@ const val THREAD_SENT_MESSAGE_ERROR = 4
 const val THREAD_SENT_MESSAGE_SUCCESS = 5
 const val THREAD_SENT_MESSAGE_SENDING = 6
 
+// allow following links in messages
+const val ALLOW_LINKS = "allow_links"
+const val ALLOW_LINKS_SENT = 1
+const val ALLOW_LINKS_RECEIVED = 2
+const val ALLOW_LINKS_ALWAYS = 3
+const val ALLOW_LINKS_NEVER = 4
+
 fun refreshMessages() {
     EventBus.getDefault().post(Events.RefreshMessages())
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -170,6 +170,38 @@
                 android:clickable="false" />
 
         </RelativeLayout>
+	
+	<RelativeLayout
+            android:id="@+id/settings_allow_links_holder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/medium_margin"
+            android:background="?attr/selectableItemBackground"
+            android:paddingLeft="@dimen/normal_margin"
+            android:paddingTop="@dimen/activity_margin"
+            android:paddingRight="@dimen/normal_margin"
+            android:paddingBottom="@dimen/activity_margin">
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_allow_links_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/settings_allow_links"
+                android:paddingLeft="@dimen/medium_margin"
+                android:paddingRight="@dimen/medium_margin"
+                android:text="@string/allow_links" />
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_allow_links"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="@dimen/medium_margin"
+                android:background="@null"
+                android:clickable="false" />
+
+        </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/settings_show_character_counter_holder"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,13 @@
     <string name="sending">Sending…</string>
     <string name="export_messages">Export messages</string>
     <string name="import_messages">Import messages</string>
+    
+    <!-- Settings --> 
+    <string name="allow_links">Allow links in messages</string>
+    <string name="allow_links_in_sent">Sent messages</string>
+    <string name="allow_links_in_received">Received messages</string>
+    <string name="allow_links_always">Always</string>
+    <string name="allow_links_never">Never</string>
 
     <!-- New conversation -->
     <string name="new_conversation">New conversation</string>


### PR DESCRIPTION
To prevent users from accidentally clicking on links in spam messages a preference to enable/disable links in messages was added. It defaults to 'Sent messages', enabling links in sent messages but disabling them in received messages.