### PR TITLE
Added SMS drafts support (#83)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -108,11 +108,25 @@ class ThreadActivity : SimpleActivity() {
 
     override fun onResume() {
         super.onResume()
+
+        val smsDraft = getSmsDraft(threadId)
+        if (smsDraft != null) {
+            thread_type_message.setText(smsDraft)
+        }
         isActivityVisible = true
     }
 
     override fun onPause() {
         super.onPause()
+
+        if (thread_type_message.value != "" && attachmentUris.isEmpty()) {
+            saveSmsDraft(thread_type_message.value, threadId)
+        } else {
+            deleteSmsDraft(threadId)
+        }
+
+        bus?.post(Events.RefreshMessages())
+
         isActivityVisible = false
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -257,6 +257,8 @@ class ConversationsAdapter(
     private fun setupView(view: View, conversation: Conversation) {
         view.apply {
             val smsDraft = context.getSmsDraft(conversation.threadId)
+            draft_indicator.beVisibleIf(smsDraft != null)
+            draft_indicator.setTextColor(adjustedPrimaryColor)
 
             conversation_frame.isSelected = selectedKeys.contains(conversation.hashCode())
 
@@ -268,10 +270,6 @@ class ConversationsAdapter(
             conversation_body_short.apply {
                 text = smsDraft ?: conversation.snippet
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, fontSize * 0.9f)
-            }
-
-            draft_indicator.apply {
-                visibility = if (smsDraft != null) View.VISIBLE else View.GONE
             }
 
             conversation_date.apply {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -23,6 +23,7 @@ import com.simplemobiletools.commons.views.MyRecyclerView
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
 import com.simplemobiletools.smsmessenger.extensions.deleteConversation
+import com.simplemobiletools.smsmessenger.extensions.getSmsDraft
 import com.simplemobiletools.smsmessenger.helpers.refreshMessages
 import com.simplemobiletools.smsmessenger.models.Conversation
 import kotlinx.android.synthetic.main.item_conversation.view.*
@@ -220,6 +221,8 @@ class ConversationsAdapter(
 
     private fun setupView(view: View, conversation: Conversation) {
         view.apply {
+            val smsDraft = context.getSmsDraft(conversation.threadId)
+
             conversation_frame.isSelected = selectedKeys.contains(conversation.hashCode())
 
             conversation_address.apply {
@@ -228,8 +231,12 @@ class ConversationsAdapter(
             }
 
             conversation_body_short.apply {
-                text = conversation.snippet
+                text = smsDraft ?: conversation.snippet
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, fontSize * 0.9f)
+            }
+
+            draft_indicator.apply {
+                visibility = if (smsDraft != null) View.VISIBLE else View.GONE
             }
 
             conversation_date.apply {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -35,9 +35,9 @@ import com.simplemobiletools.smsmessenger.interfaces.MessagesDao
 import com.simplemobiletools.smsmessenger.models.*
 import com.simplemobiletools.smsmessenger.receivers.DirectReplyReceiver
 import com.simplemobiletools.smsmessenger.receivers.MarkAsReadReceiver
+import me.leolin.shortcutbadger.ShortcutBadger
 import java.util.*
 import kotlin.collections.ArrayList
-import me.leolin.shortcutbadger.ShortcutBadger
 
 val Context.config: Config get() = Config.newInstance(applicationContext)
 
@@ -800,19 +800,20 @@ fun Context.saveSmsDraft(body: String, threadId: Long) {
 }
 
 fun Context.deleteSmsDraft(threadId: Long) {
-    val lookupUri = Sms.Draft.CONTENT_URI
-    val lookupProjection = arrayOf(Sms._ID)
-    val lookupSelection = "${Sms.THREAD_ID} = ?"
-    val lookupSelectionArgs = arrayOf(threadId.toString())
+    val uri = Sms.Draft.CONTENT_URI
+    val projection = arrayOf(Sms._ID)
+    val selection = "${Sms.THREAD_ID} = ?"
+    val selectionArgs = arrayOf(threadId.toString())
     try {
-        val cursor = contentResolver.query(lookupUri, lookupProjection, lookupSelection, lookupSelectionArgs, null)
+        val cursor = contentResolver.query(uri, projection, selection, selectionArgs, null)
         cursor.use {
             if (cursor?.moveToFirst() == true) {
                 val draftId = cursor.getLong(0)
-                val uri = Uri.withAppendedPath(Sms.CONTENT_URI, "/${draftId}")
-                contentResolver.delete(uri, null, null)
+                val draftUri = Uri.withAppendedPath(Sms.CONTENT_URI, "/${draftId}")
+                contentResolver.delete(draftUri, null, null)
             }
         }
+    } catch (e: Exception) {
     }
 }
 

--- a/app/src/main/res/layout/item_conversation.xml
+++ b/app/src/main/res/layout/item_conversation.xml
@@ -38,11 +38,25 @@
             tools:text="John" />
 
         <TextView
+            android:id="@+id/draft_indicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/conversation_address"
+            android:layout_toEndOf="@+id/conversation_image"
+            android:textColor="@color/color_primary"
+            android:textStyle="italic"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:paddingEnd="@dimen/small_margin"
+            android:textSize="@dimen/normal_text_size"
+            android:text="@string/draft" />
+
+        <TextView
             android:id="@+id/conversation_body_short"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@+id/conversation_address"
-            android:layout_toEndOf="@+id/conversation_image"
+            android:layout_toEndOf="@+id/draft_indicator"
             android:ellipsize="end"
             android:maxLines="1"
             android:paddingEnd="@dimen/activity_margin"


### PR DESCRIPTION
Hi,

I've added support for saving unfinished SMS messages as drafts and handling them correctly in the app:
- Drafts are saved in phone's memory (Telephony.Sms.Draft table).
- In the main activity, I'm showing either a draft (if exists) or last message.
- If draft is displayed in the main activity, I've added an indicator text next to it.
- In thread activity, if there's a draft, it's automatically filling the text editor (onResume).
- If there's anything in text editor, it's saved as a draft in activity's onPause.
- If text editor in a thread has been left empty, draft is removed (also in onPause).
- To keep conversations list updated, I'm invoking update event in thread activity's onPause.

What is missing is saving MMS to the drafts. I've tried to do it, but unfortunately it didn't work in a way I tried to do it (by adding manually to Mms.Part table) and also I couldn't find any documentation about it on the Internet. However, in my opinion, saving SMS as a draft is the most important part, since it's the most popular use case.

A short video showing how it works:
![17aZdLPcQC](https://user-images.githubusercontent.com/85929121/132043705-37b40b16-35ea-4b13-b62e-46ced2b3c779.gif)
