### PR TITLE
Fixed updating last message after deleting (#167)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -30,8 +30,10 @@ import com.simplemobiletools.commons.views.FastScroller
 import com.simplemobiletools.commons.views.MyRecyclerView
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
+import com.simplemobiletools.smsmessenger.activities.ThreadActivity
 import com.simplemobiletools.smsmessenger.dialogs.SelectTextDialog
 import com.simplemobiletools.smsmessenger.extensions.deleteMessage
+import com.simplemobiletools.smsmessenger.extensions.updateLastConversationMessage
 import com.simplemobiletools.smsmessenger.helpers.*
 import com.simplemobiletools.smsmessenger.models.*
 import kotlinx.android.synthetic.main.item_attachment_image.view.*
@@ -181,10 +183,12 @@ class ThreadAdapter(
 
         val messagesToRemove = getSelectedItems()
         val positions = getSelectedItemPositions()
+        val threadId = (messagesToRemove[0] as Message).threadId
         messagesToRemove.forEach {
             activity.deleteMessage((it as Message).id, it.isMMS)
         }
         messages.removeAll(messagesToRemove)
+        activity.updateLastConversationMessage(threadId)
 
         activity.runOnUiThread {
             if (messages.filter { it is Message }.isEmpty()) {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -764,3 +764,15 @@ fun Context.getLockScreenVisibilityText(type: Int) = getString(
         else -> R.string.nothing
     }
 )
+
+fun Context.updateLastConversationMessage(threadId: Long) {
+    val uri = Threads.CONTENT_URI
+    val selection = "${Threads._ID} = ?"
+    val selectionArgs = arrayOf(threadId.toString())
+    try {
+        contentResolver.delete(uri, selection, selectionArgs)
+        val newConversation = getConversations(threadId)[0]
+        conversationsDB.insertOrUpdate(newConversation)
+    } catch (e: Exception) {
+    }
+}


### PR DESCRIPTION
Hi,

I've fixed the issue that last message on conversation list wasn't updating after deleting the last message in a thread. I did it by removing the entry in Android's Thread table and then fetching data from it once again (it invokes recreating the data in it once again). It has to be done like this, because deleting the message doesn't trigger automatic update of this table, and it's impossible to update it manually.

**Before:**
![TuXiBeyjrZ](https://user-images.githubusercontent.com/85929121/132107502-7be666ac-e45d-467c-b6d5-2c89abd71b96.gif)

**After:**
![LnrRBuXvAW](https://user-images.githubusercontent.com/85929121/132107510-a10603bd-62be-49f3-a103-6eed37b664c3.gif)

