### PR TITLE
Mark as unread chats from the main messages cab

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -23,8 +23,10 @@ import com.simplemobiletools.commons.views.MyRecyclerView
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
 import com.simplemobiletools.smsmessenger.extensions.deleteConversation
+import com.simplemobiletools.smsmessenger.extensions.markThreadMessagesUnread
 import com.simplemobiletools.smsmessenger.helpers.refreshMessages
 import com.simplemobiletools.smsmessenger.models.Conversation
+import com.simplemobiletools.smsmessenger.models.Events
 import kotlinx.android.synthetic.main.item_conversation.view.*
 
 class ConversationsAdapter(
@@ -60,6 +62,7 @@ class ConversationsAdapter(
             R.id.cab_copy_number -> copyNumberToClipboard()
             R.id.cab_delete -> askConfirmDelete()
             R.id.cab_select_all -> selectAll()
+            R.id.cab_mark_as_unread -> markAsUnread()
         }
     }
 
@@ -182,6 +185,21 @@ class ConversationsAdapter(
                 }
             }
         }
+    }
+
+    private fun markAsUnread(){
+        if (selectedKeys.isEmpty()) {
+            return
+        }
+        val conversationsMarkedAsUnread = conversations.filter { selectedKeys.contains(it.hashCode()) } as ArrayList<Conversation>
+        conversationsMarkedAsUnread.forEach {
+            activity.markThreadMessagesUnread(it.threadId)
+        }
+        activity.runOnUiThread {
+            refreshMessages()
+            finishActMode()
+        }
+
     }
 
     private fun addNumberToContact() {

--- a/app/src/main/res/menu/cab_conversations.xml
+++ b/app/src/main/res/menu/cab_conversations.xml
@@ -29,4 +29,8 @@
         android:id="@+id/cab_select_all"
         android:title="@string/select_all"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_mark_as_unread"
+        android:title="@string/mark_as_unread"
+        app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
Now is possible to mark as "unread" the conversations from the main message cab, selecting also more than one chat. 

This makes easier and faster the possibility to mark conversations as "Unread" directly from the main message cab, without going inside each conversation and marking it as "unread", one by one.