### PR TITLE
Conversations can be marked as "Read" from the main message cab

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.graphics.Typeface
 import android.net.Uri
 import android.text.TextUtils
+import android.util.Log
 import android.util.TypedValue
 import android.view.Menu
 import android.view.View
@@ -191,9 +192,8 @@ class ConversationsAdapter(
             return
         }
         val  conversationsMarkedAsRead = conversations.filter { selectedKeys.contains(it.hashCode()) } as ArrayList<Conversation>
-
         ensureBackgroundThread {
-            conversationsMarkedAsRead.forEach {
+            conversationsMarkedAsRead.filter{el -> !el.read}.forEach {
                 activity.markThreadMessagesRead(it.threadId)
             }
             activity.runOnUiThread {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -23,6 +23,7 @@ import com.simplemobiletools.commons.views.MyRecyclerView
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
 import com.simplemobiletools.smsmessenger.extensions.deleteConversation
+import com.simplemobiletools.smsmessenger.extensions.markThreadMessagesRead
 import com.simplemobiletools.smsmessenger.helpers.refreshMessages
 import com.simplemobiletools.smsmessenger.models.Conversation
 import kotlinx.android.synthetic.main.item_conversation.view.*
@@ -60,6 +61,7 @@ class ConversationsAdapter(
             R.id.cab_copy_number -> copyNumberToClipboard()
             R.id.cab_delete -> askConfirmDelete()
             R.id.cab_select_all -> selectAll()
+            R.id.cab_mark_as_read -> markAsRead()
         }
     }
 
@@ -182,6 +184,24 @@ class ConversationsAdapter(
                 }
             }
         }
+    }
+
+    private fun markAsRead(){
+        if (selectedKeys.isEmpty()) {
+            return
+        }
+        val  conversationsMarkedAsRead = conversations.filter { selectedKeys.contains(it.hashCode()) } as ArrayList<Conversation>
+
+        ensureBackgroundThread {
+            conversationsMarkedAsRead.forEach {
+                activity.markThreadMessagesRead(it.threadId)
+            }
+            activity.runOnUiThread {
+                refreshMessages()
+                finishActMode()
+            }
+        }
+
     }
 
     private fun addNumberToContact() {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -210,6 +210,7 @@ class ConversationsAdapter(
         if (selectedKeys.isEmpty()) {
             return
         }
+
         val conversationsMarkedAsUnread = conversations.filter { selectedKeys.contains(it.hashCode()) } as ArrayList<Conversation>
         ensureBackgroundThread {
             conversationsMarkedAsUnread.filter { conversation -> conversation.read }.forEach {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -24,6 +24,7 @@ import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
 import com.simplemobiletools.smsmessenger.extensions.deleteConversation
 import com.simplemobiletools.smsmessenger.extensions.markThreadMessagesRead
+import com.simplemobiletools.smsmessenger.extensions.markThreadMessagesUnread
 import com.simplemobiletools.smsmessenger.helpers.refreshMessages
 import com.simplemobiletools.smsmessenger.models.Conversation
 import kotlinx.android.synthetic.main.item_conversation.view.*
@@ -61,6 +62,7 @@ class ConversationsAdapter(
             R.id.cab_copy_number -> copyNumberToClipboard()
             R.id.cab_delete -> askConfirmDelete()
             R.id.cab_select_all -> selectAll()
+            R.id.cab_mark_as_unread -> markAsUnread()
             R.id.cab_mark_as_read -> markAsRead()
         }
     }
@@ -186,21 +188,34 @@ class ConversationsAdapter(
         }
     }
 
-    private fun markAsRead(){
+    private fun markAsRead() {
         if (selectedKeys.isEmpty()) {
             return
         }
-        val  conversationsMarkedAsRead = conversations.filter { selectedKeys.contains(it.hashCode()) } as ArrayList<Conversation>
+
+        val conversationsMarkedAsRead = conversations.filter { selectedKeys.contains(it.hashCode()) } as ArrayList<Conversation>
         ensureBackgroundThread {
-            conversationsMarkedAsRead.filter{el -> !el.read}.forEach {
+            conversationsMarkedAsRead.filter { conversation -> !conversation.read }.forEach {
                 activity.markThreadMessagesRead(it.threadId)
             }
+
             activity.runOnUiThread {
                 refreshMessages()
                 finishActMode()
             }
         }
+    }
 
+    private fun markAsUnread() {
+        if (selectedKeys.isEmpty()) {
+            return
+        }
+        val conversationsMarkedAsUnread = conversations.filter { selectedKeys.contains(it.hashCode()) } as ArrayList<Conversation>
+        ensureBackgroundThread {
+            conversationsMarkedAsUnread.filter { conversation -> conversation.read }.forEach {
+                activity.markThreadMessagesUnread(it.threadId)
+            }
+        }
     }
 
     private fun addNumberToContact() {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -61,9 +61,9 @@ class ConversationsAdapter(
             R.id.cab_dial_number -> dialNumber()
             R.id.cab_copy_number -> copyNumberToClipboard()
             R.id.cab_delete -> askConfirmDelete()
-            R.id.cab_select_all -> selectAll()
-            R.id.cab_mark_as_unread -> markAsUnread()
             R.id.cab_mark_as_read -> markAsRead()
+            R.id.cab_mark_as_unread -> markAsUnread()
+            R.id.cab_select_all -> selectAll()
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.graphics.Typeface
 import android.net.Uri
 import android.text.TextUtils
-import android.util.Log
 import android.util.TypedValue
 import android.view.Menu
 import android.view.View

--- a/app/src/main/res/menu/cab_conversations.xml
+++ b/app/src/main/res/menu/cab_conversations.xml
@@ -26,11 +26,15 @@
         android:title="@string/copy_number_to_clipboard"
         app:showAsAction="never" />
     <item
-        android:id="@+id/cab_select_all"
-        android:title="@string/select_all"
-        app:showAsAction="never" />
-    <item
         android:id="@+id/cab_mark_as_read"
         android:title="@string/mark_as_read"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_mark_as_unread"
+        android:title="@string/mark_as_unread"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_select_all"
+        android:title="@string/select_all"
         app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/cab_conversations.xml
+++ b/app/src/main/res/menu/cab_conversations.xml
@@ -29,4 +29,8 @@
         android:id="@+id/cab_select_all"
         android:title="@string/select_all"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_mark_as_read"
+        android:title="@string/mark_as_read"
+        app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
As requested in #161, now the user has the possibility to mark as "Read" also those conversations he has not read yet.
This action can be done on multiple conversations.