### PR TITLE
Fixed missing plus sign when opened from another app (#107)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/NewConversationActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/NewConversationActivity.kt
@@ -102,7 +102,7 @@ class NewConversationActivity : SimpleActivity() {
 
     private fun isThirdPartyIntent(): Boolean {
         if ((intent.action == Intent.ACTION_SENDTO || intent.action == Intent.ACTION_SEND || intent.action == Intent.ACTION_VIEW) && intent.dataString != null) {
-            val number = intent.dataString!!.removePrefix("sms:").removePrefix("smsto:").removePrefix("mms").removePrefix("mmsto:").trim()
+            val number = intent.dataString!!.removePrefix("sms:").removePrefix("smsto:").removePrefix("mms").removePrefix("mmsto:").replace("+", "%2b").trim()
             launchThreadActivity(URLDecoder.decode(number), "")
             finish()
             return true

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -29,6 +29,8 @@ import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.klinker.android.send_message.Settings
 import com.klinker.android.send_message.Transaction
 import com.simplemobiletools.commons.dialogs.ConfirmationDialog
@@ -376,7 +378,10 @@ class ThreadActivity : SimpleActivity() {
     private fun setupParticipants() {
         if (participants.isEmpty()) {
             participants = if (messages.isEmpty()) {
-                getThreadParticipants(threadId, null)
+                val intentNumbers = getPhoneNumbersFromIntent()
+                val participants = getThreadParticipants(threadId, null)
+
+                fixParticipantNumbers(participants, intentNumbers)
             } else {
                 messages.first().participants
             }
@@ -765,6 +770,41 @@ class ThreadActivity : SimpleActivity() {
     private fun removeSelectedContact(id: Int) {
         participants = participants.filter { it.rawId != id }.toMutableList() as ArrayList<SimpleContact>
         showSelectedContacts()
+    }
+
+    private fun getPhoneNumbersFromIntent(): ArrayList<String> {
+        val numberFromIntent = intent.getStringExtra(THREAD_NUMBER)
+        val numbers = ArrayList<String>()
+
+        if (numberFromIntent != null) {
+            if (numberFromIntent.startsWith('[') && numberFromIntent.endsWith(']')) {
+                val type = object : TypeToken<List<String>>() {}.type
+                numbers.addAll(Gson().fromJson(numberFromIntent, type))
+            } else {
+                numbers.add(numberFromIntent)
+            }
+        }
+        return numbers
+    }
+
+    private fun fixParticipantNumbers(participants: ArrayList<SimpleContact>, properNumbers: ArrayList<String>): ArrayList<SimpleContact> {
+        for (number in properNumbers) {
+            for (participant in participants) {
+                participant.phoneNumbers = participant.phoneNumbers.map {
+                    val numberWithoutPlus = number.replace("+", "")
+                    if (numberWithoutPlus == it.trim()) {
+                        if (participant.name == it) {
+                            participant.name = number
+                        }
+                        number
+                    } else {
+                        it
+                    }
+                } as ArrayList<String>
+            }
+        }
+
+        return participants
     }
 
     @SuppressLint("MissingPermission")


### PR DESCRIPTION
Hi,

I've fixed the issue with missing plus sign after tapping send message in a third-party app. Also, in the same issue there was a related issue, that it wasn't possible to enter number with plus sign manually, that is also fixed by this PR.
Implementation details:
- Fix for plus sign was very easy - string from intent was decoded by URLDecoder that replaces `+` with a space. The solution was to replace the plus sign with its URL Encoded counterpart (`%2b`)
- The problem started later. Android caches the thread IDs after generating them, even if there was no message send. Due to this, even when I did this fix, it still wasn't working. Also, due to this, issue author couldn't write a number with plus manually - he was just writing the same number, and Android was reverting thread with the plus-less version of a number.
- To address this problem, I decided to add more logic to setupParticipants() method. Now I'm also checking if there was a number provided in an intent, and if a number taken from the threads is the same, but without a plus. If that's the case, I'm fixing it.
- It also works for group messages. I'm checking if the number text passed in an intent is a JSON array or a single string value.

**Before:**

https://user-images.githubusercontent.com/85929121/132555661-9de74b6f-7819-499c-9c81-9fd97a94fcf2.mp4

**After:**

https://user-images.githubusercontent.com/85929121/132554666-4393c1b4-a128-4f5e-872e-948e7bdc9bd2.mp4
