### PR TITLE
Fixed marking as read/unread not refreshing list

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -694,7 +694,7 @@ class ThreadActivity : SimpleActivity() {
     }
 
     private fun sendMessage() {
-        val msg = thread_type_message.value
+        var msg = thread_type_message.value
         if (msg.isEmpty() && attachmentSelections.isEmpty()) {
             return
         }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -217,6 +217,11 @@ class ConversationsAdapter(
             conversationsMarkedAsUnread.filter { conversation -> conversation.read }.forEach {
                 activity.markThreadMessagesUnread(it.threadId)
             }
+
+            activity.runOnUiThread {
+                refreshMessages()
+                finishActMode()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MarkAsReadReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MarkAsReadReceiver.kt
@@ -10,6 +10,7 @@ import com.simplemobiletools.smsmessenger.extensions.markThreadMessagesRead
 import com.simplemobiletools.smsmessenger.extensions.updateUnreadCountBadge
 import com.simplemobiletools.smsmessenger.helpers.MARK_AS_READ
 import com.simplemobiletools.smsmessenger.helpers.THREAD_ID
+import com.simplemobiletools.smsmessenger.helpers.refreshMessages
 
 class MarkAsReadReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -21,6 +22,7 @@ class MarkAsReadReceiver : BroadcastReceiver() {
                     context.markThreadMessagesRead(threadId)
                     context.conversationsDB.markRead(threadId)
                     context.updateUnreadCountBadge(context.conversationsDB.getUnreadConversations())
+                    refreshMessages()
                 }
             }
         }


### PR DESCRIPTION
Hi,

I've found a bug that "mark as read" in notification and "mark as unread" in the conversation list weren't refreshing the conversation list, therefore it looks like they weren't working. I've fixed it, and additionally I've added unselecting conversations after tapping "mark as unread" (mark as read already had it). Also, I've fixed a small compiler error in ThreadActivity.

**Before:**

https://user-images.githubusercontent.com/85929121/133305042-2bf6dc78-baca-4636-a1ef-8467a462fa5b.mp4

**After:**

https://user-images.githubusercontent.com/85929121/133304913-961e966a-d762-46aa-a84b-c78a0aca6d48.mp4

