### PR TITLE
Added hiding option "mark as read/unread" for conversations

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -43,13 +43,15 @@ class ConversationsAdapter(
     override fun getActionMenuId() = R.menu.cab_conversations
 
     override fun prepareActionMode(menu: Menu) {
+        val selectedItems = getSelectedItems()
+
         menu.apply {
             findItem(R.id.cab_block_number).isVisible = isNougatPlus()
-            findItem(R.id.cab_add_number_to_contact).isVisible = isOneItemSelected() && getSelectedItems().firstOrNull()?.isGroupConversation == false
-            findItem(R.id.cab_dial_number).isVisible = isOneItemSelected() && getSelectedItems().firstOrNull()?.isGroupConversation == false
-            findItem(R.id.cab_copy_number).isVisible = isOneItemSelected() && getSelectedItems().firstOrNull()?.isGroupConversation == false
-            findItem(R.id.cab_mark_as_read).isVisible = getSelectedItems().any { !it.read }
-            findItem(R.id.cab_mark_as_unread).isVisible = getSelectedItems().any { it.read }
+            findItem(R.id.cab_add_number_to_contact).isVisible = isOneItemSelected() && selectedItems.firstOrNull()?.isGroupConversation == false
+            findItem(R.id.cab_dial_number).isVisible = isOneItemSelected() && selectedItems.firstOrNull()?.isGroupConversation == false
+            findItem(R.id.cab_copy_number).isVisible = isOneItemSelected() && selectedItems.firstOrNull()?.isGroupConversation == false
+            findItem(R.id.cab_mark_as_read).isVisible = selectedItems.any { !it.read }
+            findItem(R.id.cab_mark_as_unread).isVisible = selectedItems.any { it.read }
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -48,6 +48,8 @@ class ConversationsAdapter(
             findItem(R.id.cab_add_number_to_contact).isVisible = isOneItemSelected() && getSelectedItems().firstOrNull()?.isGroupConversation == false
             findItem(R.id.cab_dial_number).isVisible = isOneItemSelected() && getSelectedItems().firstOrNull()?.isGroupConversation == false
             findItem(R.id.cab_copy_number).isVisible = isOneItemSelected() && getSelectedItems().firstOrNull()?.isGroupConversation == false
+            findItem(R.id.cab_mark_as_read).isVisible = getSelectedItems().any { !it.read }
+            findItem(R.id.cab_mark_as_unread).isVisible = getSelectedItems().any { it.read}
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -49,7 +49,7 @@ class ConversationsAdapter(
             findItem(R.id.cab_dial_number).isVisible = isOneItemSelected() && getSelectedItems().firstOrNull()?.isGroupConversation == false
             findItem(R.id.cab_copy_number).isVisible = isOneItemSelected() && getSelectedItems().firstOrNull()?.isGroupConversation == false
             findItem(R.id.cab_mark_as_read).isVisible = getSelectedItems().any { !it.read }
-            findItem(R.id.cab_mark_as_unread).isVisible = getSelectedItems().any { it.read}
+            findItem(R.id.cab_mark_as_unread).isVisible = getSelectedItems().any { it.read }
         }
     }
 


### PR DESCRIPTION
Hi,

Buttons to mark as read/unread were always visible despite the state of conversation. I've added simple conditions to make them appear only when it makes sense.

**Before:**

https://user-images.githubusercontent.com/85929121/133972456-0ea528fd-2fa0-41c5-9587-ad3e31a62d7a.mp4

**After:**

https://user-images.githubusercontent.com/85929121/133972473-f052327b-9aa9-4954-b4ee-0a2636641de1.mp4

