### PR TITLE
fix wrong sender name from private contacts

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -218,8 +218,8 @@ class ThreadActivity : SimpleActivity() {
             privateContacts = MyContactsContentProvider.getSimpleContacts(this, privateCursor)
             if (privateContacts.isNotEmpty()) {
                 val senderNumbersToReplace = HashMap<String, String>()
-                participants.filter { it.doesContainPhoneNumber(it.name) }.forEach { participant ->
-                    privateContacts.firstOrNull { it.doesContainPhoneNumber(participant.phoneNumbers.first()) }?.apply {
+                participants.filter { it.doesHavePhoneNumber(it.name) }.forEach { participant ->
+                    privateContacts.firstOrNull { it.doesHavePhoneNumber(participant.phoneNumbers.first()) }?.apply {
                         senderNumbersToReplace[participant.phoneNumbers.first()] = name
                         participant.name = name
                         participant.photoUri = photoUri

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -401,7 +401,7 @@ fun Context.getThreadContactNames(phoneNumbers: List<String>, privateContacts: A
         if (name != number) {
             names.add(name)
         } else {
-            val privateContact = privateContacts.firstOrNull { it.doesContainPhoneNumber(number) }
+            val privateContact = privateContacts.firstOrNull { it.doesHavePhoneNumber(number) }
             if (privateContact == null) {
                 names.add(name)
             } else {


### PR DESCRIPTION
- use `SimpleContact.doesHavePhoneNumber` to perform comparison between a sender and private contact.
- `SimpleContact.doesHavePhoneNumber` does equality check
- should address this [issue](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/128)