### PR TITLE
Changed back button behavior in thread (#187)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -159,6 +159,7 @@ class ThreadActivity : SimpleActivity() {
             R.id.delete -> askConfirmDelete()
             R.id.manage_people -> managePeople()
             R.id.mark_as_unread -> markAsUnread()
+            android.R.id.home -> onBackPressed()
             else -> return super.onOptionsItemSelected(item)
         }
         return true
@@ -169,6 +170,13 @@ class ThreadActivity : SimpleActivity() {
         if (requestCode == PICK_ATTACHMENT_INTENT && resultCode == Activity.RESULT_OK && resultData != null && resultData.data != null) {
             addAttachment(resultData.data!!)
         }
+    }
+
+    override fun onBackPressed() {
+        super.onBackPressed()
+        val intent = Intent(this, MainActivity::class.java)
+        startActivity(intent)
+        finish()
     }
 
     private fun setupCachedMessages(callback: () -> Unit) {


### PR DESCRIPTION
Hi,

I've overridden the behavior of the back button in conversation, so now it always goes back to main activity, as it was requested in a linked issue. It should fix all the problems listed there.

In the implementation, I've covered both back button in the menu and back button on the keyboard.

**Before:**

https://user-images.githubusercontent.com/85929121/134825245-7e462654-0e75-437a-bd79-8175b257b0ee.mp4

**After:**

https://user-images.githubusercontent.com/85929121/134825256-2ef60da7-ff2e-4811-83fa-fac51a649ad2.mp4
