### PR TITLE
Fixed constant loading messages text (#225)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
@@ -92,6 +92,7 @@ class MainActivity : SimpleActivity() {
             (conversations_list.adapter as? ConversationsAdapter)?.updateFontSize()
         }
 
+        (conversations_list.adapter as? ConversationsAdapter)?.updateDrafts()
         updateTextColors(main_coordinator)
         no_conversations_placeholder_2.setTextColor(getAdjustedPrimaryColor())
         no_conversations_placeholder_2.underlineText()
@@ -250,8 +251,8 @@ class MainActivity : SimpleActivity() {
                 .thenByDescending { it.date }
         ).toMutableList() as ArrayList<Conversation>
         conversations_list.beVisibleIf(hasConversations)
-        no_conversations_placeholder.beVisibleIf(!hasConversations)
-        no_conversations_placeholder_2.beVisibleIf(!hasConversations)
+        no_conversations_placeholder.beGoneIf(hasConversations)
+        no_conversations_placeholder_2.beGoneIf(hasConversations)
 
         if (!hasConversations && config.appRunCount == 1) {
             no_conversations_placeholder.text = getString(R.string.loading_messages)
@@ -279,7 +280,9 @@ class MainActivity : SimpleActivity() {
             try {
                 (currAdapter as ConversationsAdapter).updateConversations(sortedConversations)
                 if (currAdapter.conversations.isEmpty()) {
+                    conversations_list.beGone()
                     no_conversations_placeholder.text = getString(R.string.no_conversations_found)
+                    no_conversations_placeholder.beVisible()
                     no_conversations_placeholder_2.beVisible()
                 }
             } catch (ignored: Exception) {


### PR DESCRIPTION
Hi,

I've fixed the issue that the text of loading messages was constantly visible when there weren't any conversations on the device, and starting the app at the first launch.

**Before:**

https://user-images.githubusercontent.com/85929121/136748976-c2e7fb27-07b9-4def-9835-677cf8908edd.mp4

**After:**

https://user-images.githubusercontent.com/85929121/136749013-1f476fdf-fa51-4c8c-950a-0bc49061225a.mp4



