### PR TITLE
handle long-press of message bubble

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:f1ba19dcc0'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:4222d24832'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'com.klinkerapps:android-smsmms:5.2.6'
     implementation 'com.github.tibbi:IndicatorFastScroll:c3de1d040a'

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -117,7 +117,7 @@ class ThreadAdapter(
                 is ThreadSent -> setupThreadSuccess(itemView, item.delivered)
                 is ThreadError -> setupThreadError(itemView)
                 is ThreadSending -> setupThreadSending(itemView)
-                else -> setupView(itemView, item as Message)
+                else -> setupView(holder, itemView, item as Message)
             }
         }
         bindViewHolder(holder)
@@ -214,7 +214,7 @@ class ThreadAdapter(
         }
     }
 
-    private fun setupView(view: View, message: Message) {
+    private fun setupView(holder: ViewHolder, view: View, message: Message) {
         view.apply {
             thread_message_holder.isSelected = selectedKeys.contains(message.hashCode())
             thread_message_body.apply {
@@ -236,6 +236,15 @@ class ThreadAdapter(
                 val contrastColor = background.getContrastColor()
                 thread_message_body.setTextColor(contrastColor)
                 thread_message_body.setLinkTextColor(contrastColor)
+            }
+
+            thread_message_body.setOnLongClickListener {
+                holder.viewLongClicked()
+                true
+            }
+
+            thread_message_body.setOnClickListener {
+                holder.viewClicked(message)
             }
 
             thread_mesage_attachments_holder.removeAllViews()

--- a/app/src/main/res/menu/cab_thread.xml
+++ b/app/src/main/res/menu/cab_thread.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/cab_copy_to_clipboard"
-        android:icon="@drawable/ic_copy"
+        android:icon="@drawable/ic_copy_vector"
         android:title="@string/copy_to_clipboard"
         app:showAsAction="always" />
     <item


### PR DESCRIPTION
**Notes**
- handle long-press of a message bubble
- update commons dependency
- fix broken drawable resource reference in `cab_thread` menu file
- should address this [issue](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/139)
- [this PR](https://github.com/SimpleMobileTools/Simple-Commons/pull/1193) in the commons library needs to be merged before it can be built 

**Screenshot**

https://user-images.githubusercontent.com/25648077/141169306-0aa228d8-a55e-4ace-8c2a-6c7ef60a86e4.mov


