### PR TITLE
Added saving MMS (#106)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -30,6 +30,7 @@ import com.simplemobiletools.commons.views.FastScroller
 import com.simplemobiletools.commons.views.MyRecyclerView
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
+import com.simplemobiletools.smsmessenger.activities.ThreadActivity
 import com.simplemobiletools.smsmessenger.dialogs.SelectTextDialog
 import com.simplemobiletools.smsmessenger.extensions.deleteMessage
 import com.simplemobiletools.smsmessenger.extensions.updateLastConversationMessage
@@ -62,10 +63,13 @@ class ThreadAdapter(
 
     override fun prepareActionMode(menu: Menu) {
         val isOneItemSelected = isOneItemSelected()
+        val selectedItem = getSelectedItems().firstOrNull() as? Message
+        val hasText = selectedItem?.body != null && selectedItem.body != ""
         menu.apply {
-            findItem(R.id.cab_copy_to_clipboard).isVisible = isOneItemSelected
-            findItem(R.id.cab_share).isVisible = isOneItemSelected
-            findItem(R.id.cab_select_text).isVisible = isOneItemSelected
+            findItem(R.id.cab_copy_to_clipboard).isVisible = isOneItemSelected && hasText
+            findItem(R.id.cab_save_as).isVisible = isOneItemSelected && selectedItem?.attachment?.attachments?.size == 1
+            findItem(R.id.cab_share).isVisible = isOneItemSelected && hasText
+            findItem(R.id.cab_select_text).isVisible = isOneItemSelected && hasText
         }
     }
 
@@ -76,6 +80,7 @@ class ThreadAdapter(
 
         when (id) {
             R.id.cab_copy_to_clipboard -> copyToClipboard()
+            R.id.cab_save_as -> saveAs()
             R.id.cab_share -> shareText()
             R.id.cab_select_text -> selectText()
             R.id.cab_delete -> askConfirmDelete()
@@ -140,6 +145,12 @@ class ThreadAdapter(
     private fun copyToClipboard() {
         val firstItem = getSelectedItems().firstOrNull() as? Message ?: return
         activity.copyToClipboard(firstItem.body)
+    }
+
+    private fun saveAs() {
+        val firstItem = getSelectedItems().firstOrNull() as? Message ?: return
+        val attachment = firstItem.attachment?.attachments?.first() ?: return
+        (activity as ThreadActivity).saveMMS(attachment.mimetype, attachment.uriString)
     }
 
     private fun shareText() {

--- a/app/src/main/res/menu/cab_thread.xml
+++ b/app/src/main/res/menu/cab_thread.xml
@@ -7,11 +7,6 @@
         android:title="@string/copy_to_clipboard"
         app:showAsAction="always" />
     <item
-        android:id="@+id/cab_save_as"
-        android:icon="@drawable/ic_save_vector"
-        android:title="@string/save_as"
-        app:showAsAction="always" />
-    <item
         android:id="@+id/cab_share"
         android:icon="@drawable/ic_share_vector"
         android:title="@string/share"
@@ -20,7 +15,12 @@
         android:id="@+id/cab_delete"
         android:icon="@drawable/ic_delete_vector"
         android:title="@string/delete"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/cab_save_as"
+        android:icon="@drawable/ic_save_vector"
+        android:title="@string/save_as"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/cab_select_text"
         android:title="@string/select_text"

--- a/app/src/main/res/menu/cab_thread.xml
+++ b/app/src/main/res/menu/cab_thread.xml
@@ -7,6 +7,11 @@
         android:title="@string/copy_to_clipboard"
         app:showAsAction="always" />
     <item
+        android:id="@+id/cab_save_as"
+        android:icon="@drawable/ic_save_vector"
+        android:title="@string/save_as"
+        app:showAsAction="always" />
+    <item
         android:id="@+id/cab_share"
         android:icon="@drawable/ic_share_vector"
         android:title="@string/share"


### PR DESCRIPTION
Hi,

I've added an ability to save MMS attachment. It looks like this:
- Currently it's saving only one attachment, saving multiple would be hard to achieve without permissions to write to storage.
- It should work with any kind of attachment. I've tested it only with images and videos, but since I'm just copying the original mime type from the attachment, it should also work with contact cards or other attachments.
- As a file name, I'm taking the MMS ID from the database.
- I've hidden buttons for copy, share and select text for MMS when they don't have text, since they work only for text.

https://user-images.githubusercontent.com/85929121/142726647-1a75a863-53f7-4d69-b726-2473e6f378d7.mp4

