### PR TITLE
Fixed disabled mark as read in notification

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -716,7 +716,7 @@ fun Context.showMessageNotification(address: String, body: String, threadId: Lon
         putExtra(THREAD_ID, threadId)
     }
 
-    val markAsReadPendingIntent = PendingIntent.getBroadcast(this, 0, markAsReadIntent, PendingIntent.FLAG_CANCEL_CURRENT)
+    val markAsReadPendingIntent = PendingIntent.getBroadcast(this, threadId.hashCode(), markAsReadIntent, PendingIntent.FLAG_UPDATE_CURRENT)
     var replyAction: NotificationCompat.Action? = null
 
     if (isNougatPlus()) {


### PR DESCRIPTION
Hi,

I've noticed that when receiving multiple notifications, only the newest one has active the mark as read button. After tapping the active one, the rest were still inactive.

**Before:**

https://user-images.githubusercontent.com/85929121/149197851-9ecc54a9-3f24-40d6-8486-1de52c226a76.mp4

**After:**

https://user-images.githubusercontent.com/85929121/149197877-2fee0ade-032f-4129-83e8-cc9cd6a40b89.mp4
