### PR TITLE
Fixed private contacts not showing in group autocomplete

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -231,6 +231,8 @@ class ThreadActivity : SimpleActivity() {
     private fun setupThread() {
         val privateCursor = getMyContactsCursor(false, true)?.loadInBackground()
         ensureBackgroundThread {
+            privateContacts = MyContactsContentProvider.getSimpleContacts(this, privateCursor)
+
             val cachedMessagesCode = messages.clone().hashCode()
             messages = getMessages(threadId)
 
@@ -240,6 +242,7 @@ class ThreadActivity : SimpleActivity() {
 
             try {
                 if (participants.isNotEmpty() && messages.hashCode() == cachedMessagesCode && !hasParticipantWithoutName) {
+                    setupAdapter()
                     return@ensureBackgroundThread
                 }
             } catch (ignored: Exception) {
@@ -248,7 +251,6 @@ class ThreadActivity : SimpleActivity() {
             setupParticipants()
 
             // check if no participant came from a privately stored contact in Simple Contacts
-            privateContacts = MyContactsContentProvider.getSimpleContacts(this, privateCursor)
             if (privateContacts.isNotEmpty()) {
                 val senderNumbersToReplace = HashMap<String, String>()
                 participants.filter { it.doesHavePhoneNumber(it.name) }.forEach { participant ->


### PR DESCRIPTION
Hi,

I've found a bug, that it wasn't possible to add a private contact to the group if the existing thread was with a public contact. To fix it, I had to move the private contacts fetching above the first return, because the list was always empty for public contact threads.

**Before:**

https://user-images.githubusercontent.com/85929121/150825917-bc22fa05-c202-44ae-8447-0fc50b7e92d3.mp4

**After:**

https://user-images.githubusercontent.com/85929121/150825937-6930d248-e725-4d9c-b3e7-1be3045733df.mp4
