### PR TITLE
Downsize big images

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -673,11 +673,7 @@ class ThreadActivity : SimpleActivity() {
                         loadAttachmentPreview(attachmentView, compressedUri)
                     } else {
                         toast(R.string.compress_error)
-                        thread_attachments_wrapper.removeView(attachmentView)
-                        attachmentSelections.remove(originalUriString)
-                        if (attachmentSelections.isEmpty()) {
-                            thread_attachments_holder.beGone()
-                        }
+                        removeAttachment(attachmentView, originalUriString)
                     }
                     checkSendMessageAvailability()
                     attachmentView.thread_attachment_progress.beGone()
@@ -691,11 +687,7 @@ class ThreadActivity : SimpleActivity() {
         val attachmentView = layoutInflater.inflate(R.layout.item_attachment, null).apply {
             thread_attachments_wrapper.addView(this)
             thread_remove_attachment.setOnClickListener {
-                thread_attachments_wrapper.removeView(this)
-                attachmentSelections.remove(originalUri)
-                if (attachmentSelections.isEmpty()) {
-                    thread_attachments_holder.beGone()
-                }
+                removeAttachment(this, originalUri)
             }
         }
 
@@ -732,6 +724,14 @@ class ThreadActivity : SimpleActivity() {
                 }
             })
             .into(attachmentView.thread_attachment_preview)
+    }
+
+    private fun removeAttachment(attachmentView: View, originalUri: String) {
+        thread_attachments_wrapper.removeView(attachmentView)
+        attachmentSelections.remove(originalUri)
+        if (attachmentSelections.isEmpty()) {
+            thread_attachments_holder.beGone()
+        }
     }
 
     private fun checkSendMessageAvailability() {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -671,6 +671,13 @@ class ThreadActivity : SimpleActivity() {
                     if (compressedUri != null) {
                         attachmentSelections[originalUriString] = AttachmentSelection(compressedUri, false)
                         loadAttachmentPreview(attachmentView, compressedUri)
+                    } else {
+                        toast(R.string.compress_error)
+                        thread_attachments_wrapper.removeView(attachmentView)
+                        attachmentSelections.remove(originalUriString)
+                        if (attachmentSelections.isEmpty()) {
+                            thread_attachments_holder.beGone()
+                        }
                     }
                     checkSendMessageAvailability()
                     attachmentView.thread_attachment_progress.beGone()

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt
@@ -106,7 +106,11 @@ class ImageCompressor(private val context: Context) {
         private var iteration: Int = 0
 
         fun isSatisfied(imageFile: File): Boolean {
-            return imageFile.length() <= maxFileSize || iteration >= maxIteration
+            // If size requirement is not met and iteration is maxed
+            if(iteration >= maxIteration && imageFile.length() >= maxFileSize) {
+                throw Exception("Unable to compress image to targeted size")
+            }
+            return imageFile.length() <= maxFileSize
         }
 
         fun satisfy(imageFile: File): File {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">تثبيت في الأعلى</string>
     <string name="unpin_conversation">ازالة التثبيت</string>
     <string name="forward_message">اعادة ارسال</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">محادثة جديدة</string>
     <string name="add_contact_or_number">إضافة جهة اتصال أو رقم …</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Fixa a la part superior</string>
     <string name="unpin_conversation">No fixis</string>
     <string name="forward_message">Reenvia</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Conversa nova</string>
     <string name="add_contact_or_number">Afegeix un contacte o número…</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Nová konverzace</string>
     <string name="add_contact_or_number">Přidejte kontakt nebo číslo…</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Ny Samtale</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Oben anheften</string>
     <string name="unpin_conversation">Losheften</string>
     <string name="forward_message">Weiterleiten</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Neuer Chat</string>
     <string name="add_contact_or_number">Kontakt oder Nummer hinzufügen …</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Καρφίτσωμα στην κορυφή</string>
     <string name="unpin_conversation">Ξεκαρφίτσωμα</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Νέα συνομιλία</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Alpingli supren</string>
     <string name="unpin_conversation">Depingli</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">New conversation</string>
     <string name="add_contact_or_number">Add Contact or Number…</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Nueva conversación</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Eemalda kinnitus</string>
     <string name="forward_message">Edasta</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Uus vestlus</string>
     <string name="add_contact_or_number">Add Contact or Number…</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Uusi keskustelu</string>
     <string name="add_contact_or_number">Lisää yhteystieto tai numero…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Épingler en haut</string>
     <string name="unpin_conversation">Désépingler</string>
     <string name="forward_message">Transférer</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Nouvelle conversation</string>
     <string name="add_contact_or_number">Ajouter un contact ou un numéro…</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Nova conversa</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Kitűzés fentre</string>
     <string name="unpin_conversation">Kitűzés megszüntetése</string>
     <string name="forward_message">Továbbítás</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Új beszélgetés</string>
     <string name="add_contact_or_number">Névjegy vagy szám hozzáadása…</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Percakapan baru</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Fissa in alto</string>
     <string name="unpin_conversation">Rimuovi</string>
     <string name="forward_message">Inoltra</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Nuova conversazione</string>
     <string name="add_contact_or_number">Inserisci contatto o numero…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">新しい会話</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Naujas pokalbis</string>
     <string name="add_contact_or_number">Pridėti kontaktą arba numerį…</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">പുതിയ സംഭാഷണം</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Fest til toppen</string>
     <string name="unpin_conversation">Løsne</string>
     <string name="forward_message">Videresend</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Ny samtale</string>
     <string name="add_contact_or_number">Legg til kontakt eller nummer …</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Bovenaan vastzetten</string>
     <string name="unpin_conversation">Losmaken</string>
     <string name="forward_message">Doorsturen</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Nieuw gesprek</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Przypnij na górze</string>
     <string name="unpin_conversation">Odepnij</string>
     <string name="forward_message">Przekaż dalej</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Nowa rozmowa</string>
     <string name="add_contact_or_number">Dodaj kontakt lub numer…</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Fixar no topo</string>
     <string name="unpin_conversation">Desafixar</string>
     <string name="forward_message">Reencaminhar</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Nova conversa</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Fixare în vârf</string>
     <string name="unpin_conversation">Elimină fixarea</string>
     <string name="forward_message">Redirecţionare</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Conversaţie nouă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Закрепить сверху</string>
     <string name="unpin_conversation">Открепить</string>
     <string name="forward_message">Переслать</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Новая переписка</string>
     <string name="add_contact_or_number">Добавить контакт или номер…</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Pripnúť na vrch</string>
     <string name="unpin_conversation">Odopnúť</string>
     <string name="forward_message">Preposlať</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Nová konverzácia</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">மேலே பொருத்தவும்</string>
     <string name="unpin_conversation">அன்பின்</string>
     <string name="forward_message">முன்னோக்கி</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">புதிய உரையாடல்</string>
     <string name="add_contact_or_number">தொடர்பு அல்லது எண்ணைச் சேர்க்கவும்…</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">En üste sabitle</string>
     <string name="unpin_conversation">Sabitlemeyi kaldır</string>
     <string name="forward_message">İlet</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">Yeni görüşme</string>
     <string name="add_contact_or_number">Kişi veya Numara Ekle…</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -18,6 +18,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
 
     <!-- New conversation -->
     <string name="new_conversation">Нове листування</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">置顶固定</string>
     <string name="unpin_conversation">取消固定</string>
     <string name="forward_message">转发</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">新的对话</string>
     <string name="add_contact_or_number">添加联系人或者号码…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="pin_conversation">Pin to the top</string>
     <string name="unpin_conversation">Unpin</string>
     <string name="forward_message">Forward</string>
+    <string name="compress_error">Unable to compress image to selected size</string>
     <!-- New conversation -->
     <string name="new_conversation">New conversation</string>
     <string name="add_contact_or_number">Add Contact or Number…</string>


### PR DESCRIPTION
Closes  #284

Come along with #285 as I think both features should be implemented. I can rebase and drop commits if needed.

**The goal is to get a overall quality when trying to downsize images if the target size is hard to reach.**

I choose to use a pretty simple method:

If the image size is a least twice as big as the target size, I cut the resolution (both width & height) in half.
The results are very nice:
- With an option set to 600kb
With a input image of 4.56Mb & w:2304 x h:4096
I get a 594 Kb image with a very nice image, no visible compression artifacts & decent resolution

**Icing on the cake, the downsizing is under a second when it was around 3 seconds without the resolution cut.**
Probably due to multiple compression loop.

All compression / resolution algorithm credits goes to https://github.com/zetbaitsu and his Compressor lib, I just Copy/Pasted it.
