### PR TITLE
WIP: Option to encrypt message exports

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,21 +41,7 @@
             android:name=".activities.SplashActivity"
             android:theme="@style/SplashTheme" />
 
-        <activity android:name=".activities.MainActivity" >
-            <intent-filter>
-                <action android:name="android.intent.action.GET_CONTENT" />
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.OPENABLE"/>
-                <data android:scheme="file" />
-                <data android:mimeType="application/octet-stream" />
-                <data android:pathPattern=".*\\.sec" />
-                <data android:pathPattern=".*\\..*\\.sec"/>
-                <data android:pathPattern=".*\\..*\\..*\\.sec"/>
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.sec"/>
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.sec"/>
-                <data android:host="*" />
-            </intent-filter>
-        </activity>
+        <activity android:name=".activities.MainActivity"/>
 
         <activity
             android:name=".activities.ThreadActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,21 @@
             android:name=".activities.SplashActivity"
             android:theme="@style/SplashTheme" />
 
-        <activity android:name=".activities.MainActivity" />
+        <activity android:name=".activities.MainActivity" >
+            <intent-filter>
+                <action android:name="android.intent.action.GET_CONTENT" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.OPENABLE"/>
+                <data android:scheme="file" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:pathPattern=".*\\.sec" />
+                <data android:pathPattern=".*\\..*\\.sec"/>
+                <data android:pathPattern=".*\\..*\\..*\\.sec"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.sec"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.sec"/>
+                <data android:host="*" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".activities.ThreadActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
             android:name=".activities.SplashActivity"
             android:theme="@style/SplashTheme" />
 
-        <activity android:name=".activities.MainActivity"/>
+        <activity android:name=".activities.MainActivity" />
 
         <activity
             android:name=".activities.ThreadActivity"

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/ExportMessagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/ExportMessagesDialog.kt
@@ -8,6 +8,7 @@ import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
 import com.simplemobiletools.smsmessenger.extensions.config
 import com.simplemobiletools.smsmessenger.helpers.EXPORT_FILE_EXT
+import com.simplemobiletools.smsmessenger.helpers.EXPORT_SECURE_FILE_EXT
 import kotlinx.android.synthetic.main.dialog_export_messages.view.*
 import java.io.File
 
@@ -51,7 +52,8 @@ class ExportMessagesDialog(
                         when {
                             filename.isEmpty() -> activity.toast(R.string.empty_name)
                             filename.isAValidFilename() -> {
-                                val file = File(realPath, "$filename$EXPORT_FILE_EXT")
+                                config.exportBackupPassword = view.export_messages_password.value //We need to get this early to set proper extension
+                                val file = if (config.exportBackupPassword == "") File(realPath, "$filename$EXPORT_FILE_EXT") else File(realPath, "$filename$EXPORT_SECURE_FILE_EXT")
                                 if (!hidePath && file.exists()) {
                                     activity.toast(R.string.name_taken)
                                     return@setOnClickListener

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/ImportMessagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/ImportMessagesDialog.kt
@@ -1,9 +1,13 @@
 package com.simplemobiletools.smsmessenger.dialogs
 
+import android.util.Log
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
+import androidx.documentfile.provider.DocumentFile
+import com.simplemobiletools.commons.extensions.beGone
 import com.simplemobiletools.commons.extensions.setupDialogStuff
 import com.simplemobiletools.commons.extensions.toast
+import com.simplemobiletools.commons.extensions.value
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
@@ -15,7 +19,8 @@ import kotlinx.android.synthetic.main.dialog_import_messages.view.*
 
 class ImportMessagesDialog(
     private val activity: SimpleActivity,
-    private val path: String,
+    private val path: String?,
+    private var file: DocumentFile?,
 ) {
 
     private val config = activity.config
@@ -25,6 +30,11 @@ class ImportMessagesDialog(
         val view = (activity.layoutInflater.inflate(R.layout.dialog_import_messages, null) as ViewGroup).apply {
             import_sms_checkbox.isChecked = config.importSms
             import_mms_checkbox.isChecked = config.importMms
+        }
+        if (path?.substringAfterLast(".", "") != "sec" || file.name.replaceAfterLast(".","") != "sec")
+        {
+            view.import_messages_password.beGone()
+            view.import_messages_password_label.beGone()
         }
 
         AlertDialog.Builder(activity)
@@ -46,6 +56,7 @@ class ImportMessagesDialog(
                         activity.toast(R.string.importing)
                         config.importSms = view.import_sms_checkbox.isChecked
                         config.importMms = view.import_mms_checkbox.isChecked
+                        config.exportBackupPassword = view.import_messages_password.value
                         ensureBackgroundThread {
                             MessagesImporter(activity).importMessages(path) {
                                 handleParseResult(it)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/ImportMessagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/ImportMessagesDialog.kt
@@ -1,10 +1,8 @@
 package com.simplemobiletools.smsmessenger.dialogs
 
-import android.util.Log
+
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
-import androidx.documentfile.provider.DocumentFile
-import com.simplemobiletools.commons.extensions.beGone
 import com.simplemobiletools.commons.extensions.setupDialogStuff
 import com.simplemobiletools.commons.extensions.toast
 import com.simplemobiletools.commons.extensions.value

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/ImportMessagesDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/ImportMessagesDialog.kt
@@ -16,11 +16,11 @@ import com.simplemobiletools.smsmessenger.helpers.MessagesImporter
 import com.simplemobiletools.smsmessenger.helpers.MessagesImporter.ImportResult.IMPORT_OK
 import com.simplemobiletools.smsmessenger.helpers.MessagesImporter.ImportResult.IMPORT_PARTIAL
 import kotlinx.android.synthetic.main.dialog_import_messages.view.*
+import java.io.InputStream
 
 class ImportMessagesDialog(
     private val activity: SimpleActivity,
-    private val path: String?,
-    private var file: DocumentFile?,
+    private val path: String,
 ) {
 
     private val config = activity.config
@@ -30,11 +30,6 @@ class ImportMessagesDialog(
         val view = (activity.layoutInflater.inflate(R.layout.dialog_import_messages, null) as ViewGroup).apply {
             import_sms_checkbox.isChecked = config.importSms
             import_mms_checkbox.isChecked = config.importMms
-        }
-        if (path?.substringAfterLast(".", "") != "sec" || file.name.replaceAfterLast(".","") != "sec")
-        {
-            view.import_messages_password.beGone()
-            view.import_messages_password_label.beGone()
         }
 
         AlertDialog.Builder(activity)
@@ -56,7 +51,7 @@ class ImportMessagesDialog(
                         activity.toast(R.string.importing)
                         config.importSms = view.import_sms_checkbox.isChecked
                         config.importMms = view.import_mms_checkbox.isChecked
-                        config.exportBackupPassword = view.import_messages_password.value
+                        config.importBackupPassword = view.import_messages_password.value
                         ensureBackgroundThread {
                             MessagesImporter(activity).importMessages(path) {
                                 handleParseResult(it)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Config.kt
@@ -64,6 +64,10 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getString(LAST_EXPORT_PATH, "")!!
         set(lastExportPath) = prefs.edit().putString(LAST_EXPORT_PATH, lastExportPath).apply()
 
+    var exportBackupPassword: String
+        get() = prefs.getString(EXPORT_BACKUP_PASSWORD, "")!!
+        set(exportBackupPassword) = prefs.edit().putString(EXPORT_BACKUP_PASSWORD, exportBackupPassword).apply()
+
     var exportSms: Boolean
         get() = prefs.getBoolean(EXPORT_SMS, true)
         set(exportSms) = prefs.edit().putBoolean(EXPORT_SMS, exportSms).apply()
@@ -71,6 +75,10 @@ class Config(context: Context) : BaseConfig(context) {
     var exportMms: Boolean
         get() = prefs.getBoolean(EXPORT_MMS, true)
         set(exportMms) = prefs.edit().putBoolean(EXPORT_MMS, exportMms).apply()
+
+    var importBackupPassword: String
+        get() = prefs.getString(IMPORT_BACKUP_PASSWORD, "")!!
+        set(importBackupPassword) = prefs.edit().putString(IMPORT_BACKUP_PASSWORD, importBackupPassword).apply()
 
     var importSms: Boolean
         get() = prefs.getBoolean(IMPORT_SMS, true)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Constants.kt
@@ -20,13 +20,21 @@ const val SEND_LONG_MESSAGE_MMS = "send_long_message_mms"
 const val MMS_FILE_SIZE_LIMIT = "mms_file_size_limit"
 const val PINNED_CONVERSATIONS = "pinned_conversations"
 const val LAST_EXPORT_PATH = "last_export_path"
+const val EXPORT_BACKUP_PASSWORD = "export_backup_password"
 const val EXPORT_SMS = "export_sms"
 const val EXPORT_MMS = "export_mms"
 const val EXPORT_MIME_TYPE = "application/json"
+const val EXPORT_SECURE_MIME_TYPE = "application/sec"
 const val EXPORT_FILE_EXT = ".json"
+const val EXPORT_SECURE_FILE_EXT = ".sec"
+const val IMPORT_BACKUP_PASSWORD = "import_backup_password"
 const val IMPORT_SMS = "import_sms"
 const val IMPORT_MMS = "import_mms"
 const val WAS_DB_CLEARED = "was_db_cleared"
+
+//Secure Backup Cipher Parameters
+const val KEY_ITERATIONS = 65536
+const val KEY_LENGTH = 256
 
 private const val PATH = "com.simplemobiletools.smsmessenger.action."
 const val MARK_AS_READ = PATH + "mark_as_read"

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesExporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesExporter.kt
@@ -1,12 +1,22 @@
 package com.simplemobiletools.smsmessenger.helpers
 
 import android.content.Context
+import android.util.Log
 import com.google.gson.Gson
-import com.google.gson.stream.JsonWriter
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.smsmessenger.extensions.config
 import com.simplemobiletools.smsmessenger.extensions.getConversationIds
+import org.json.JSONArray
+import org.json.JSONObject
 import java.io.OutputStream
+import java.security.SecureRandom
+import java.security.spec.KeySpec
+import javax.crypto.Cipher
+import javax.crypto.CipherOutputStream
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+
 
 class MessagesExporter(private val context: Context) {
     enum class ExportResult {
@@ -23,45 +33,75 @@ class MessagesExporter(private val context: Context) {
                 callback.invoke(ExportResult.EXPORT_FAIL)
                 return@ensureBackgroundThread
             }
-            val writer = JsonWriter(outputStream.bufferedWriter())
-            writer.use {
-                try {
-                    var written = 0
-                    writer.beginArray()
-                    val conversationIds = context.getConversationIds()
-                    val totalMessages = messageReader.getMessagesCount()
-                    for (threadId in conversationIds) {
-                        writer.beginObject()
-                        if (config.exportSms && messageReader.getSmsCount() > 0) {
-                            writer.name("sms")
-                            writer.beginArray()
-                            messageReader.forEachSms(threadId) {
-                                writer.jsonValue(gson.toJson(it))
-                                written++
-                                onProgress.invoke(totalMessages, written)
-                            }
-                            writer.endArray()
+
+            //To keep same layout as previous version and avoid rewriting importer
+            val mainArray = JSONArray()
+
+            //Main object containing Array of object jSMS & jMMS
+            val mainObject = JSONObject()
+
+            val jSMS = JSONArray()
+            val jMMS = JSONArray()
+
+            try {
+                var written = 0
+                val conversationIds = context.getConversationIds()
+                val totalMessages = messageReader.getMessagesCount()
+                for (threadId in conversationIds) {
+
+                    if (config.exportSms && messageReader.getSmsCount() > 0) {
+                        messageReader.forEachSms(threadId) {
+                            jSMS.put(JSONObject(gson.toJson(it)))
+                            written++
+                            onProgress.invoke(totalMessages, written)
                         }
-
-                        if (config.exportMms && messageReader.getMmsCount() > 0) {
-                            writer.name("mms")
-                            writer.beginArray()
-                            messageReader.forEachMms(threadId) {
-                                writer.jsonValue(gson.toJson(it))
-                                written++
-                                onProgress.invoke(totalMessages, written)
-                            }
-
-                            writer.endArray()
-                        }
-
-                        writer.endObject()
                     }
-                    writer.endArray()
-                    callback.invoke(ExportResult.EXPORT_OK)
-                } catch (e: Exception) {
-                    callback.invoke(ExportResult.EXPORT_FAIL)
+
+                    if (config.exportMms && messageReader.getMmsCount() > 0) {
+                        messageReader.forEachMms(threadId) {
+                            jMMS.put(JSONObject(gson.toJson(it)))
+                            written++
+                            onProgress.invoke(totalMessages, written)
+                        }
+                    }
                 }
+                if (jSMS.length() > 0) mainObject.put("sms", jSMS)
+                if (jMMS.length() > 0) mainObject.put("mms", jMMS)
+
+                mainArray.put(mainObject)
+                Log.d("debugFilePath", config.lastExportPath)
+                if (config.exportBackupPassword == "")
+                {
+                    //If user didn't set a password we simply save the json in plain
+                    outputStream.write(mainArray.toString().encodeToByteArray())
+                }
+                else
+                {
+                    Log.d("debugFilePath", config.lastExportPath)
+                    val salt = ByteArray(16)
+                    val random = SecureRandom()
+                    random.nextBytes(salt)
+
+                    //Taken from FairEmail project (setting export mechanism)
+                    // https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Cipher
+                    val keyFactory: SecretKeyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
+                    val keySpec: KeySpec = PBEKeySpec(config.exportBackupPassword.toCharArray(), salt, KEY_ITERATIONS, KEY_LENGTH)
+                    val secret: SecretKey = keyFactory.generateSecret(keySpec)
+                    val cipher: Cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+                    cipher.init(Cipher.ENCRYPT_MODE, secret)
+
+                    outputStream.write(salt)
+                    outputStream.write(cipher.iv)
+
+                    val cout: OutputStream = CipherOutputStream(outputStream, cipher)
+                    cout.write(mainArray.toString().toByteArray())
+                    cout.flush()
+                    outputStream.write(cipher.doFinal())
+
+                }
+                callback.invoke(ExportResult.EXPORT_OK)
+            } catch (e: Exception) {
+                callback.invoke(ExportResult.EXPORT_FAIL)
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesExporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesExporter.kt
@@ -94,7 +94,9 @@ class MessagesExporter(private val context: Context) {
                     outputStream.write(cipher.iv)
 
                     val cout: OutputStream = CipherOutputStream(outputStream, cipher)
-                    cout.write(mainArray.toString().toByteArray())
+                    cout.bufferedWriter().use { writer ->
+                        cout.write(mainArray.toString().toByteArray())
+                    }
                     cout.flush()
                     outputStream.write(cipher.doFinal())
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesImporter.kt
@@ -1,7 +1,11 @@
 package com.simplemobiletools.smsmessenger.helpers
 
+import android.R.attr.password
 import android.content.Context
 import android.provider.Telephony.*
+import android.text.TextUtils
+import androidx.appcompat.widget.ThemedSpinnerAdapter.Helper
+import androidx.documentfile.provider.DocumentFile
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.simplemobiletools.commons.extensions.showErrorToast
@@ -9,11 +13,19 @@ import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.smsmessenger.extensions.*
 import com.simplemobiletools.smsmessenger.helpers.MessagesImporter.ImportResult.*
 import com.simplemobiletools.smsmessenger.models.ExportedMessage
-import java.io.File
+import java.io.*
+import java.security.spec.KeySpec
+import javax.crypto.Cipher
+import javax.crypto.CipherInputStream
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.PBEKeySpec
+
 
 class MessagesImporter(private val context: Context) {
     enum class ImportResult {
-        IMPORT_FAIL, IMPORT_OK, IMPORT_PARTIAL, IMPORT_NOTHING_NEW
+        IMPORT_FAIL, IMPORT_OK, IMPORT_PARTIAL, IMPORT_NOTHING_NEW, NO_PASSWORD_PROVIDED
     }
 
     private val gson = Gson()
@@ -21,16 +33,72 @@ class MessagesImporter(private val context: Context) {
     private val config = context.config
     private var messagesImported = 0
     private var messagesFailed = 0
+    private var errorPassword : Boolean = false
 
-    fun importMessages(path: String, onProgress: (total: Int, current: Int) -> Unit = { _, _ -> }, callback: (result: ImportResult) -> Unit) {
+    fun readBuffer(inputStream: InputStream, buffer: ByteArray)
+    {
+        var left = buffer.size
+
+        while(left > 0)
+        {
+            val count = inputStream.read(buffer, buffer.size - left, left)
+            if (count < 0)
+                throw Exception("Bad file encryption")
+            left -= count
+        }
+    }
+
+    fun importMessages(path: String?, file: DocumentFile?, onProgress: (total: Int, current: Int) -> Unit = { _, _ -> }, callback: (result: ImportResult) -> Unit) {
         ensureBackgroundThread {
             try {
+                //if extension is not "sec" then the file must be not encrypted
+                var inputStream: InputStream
 
-                val inputStream = if (path.contains("/")) {
-                    File(path).inputStream()
-                } else {
-                    context.assets.open(path)
+                if(path != null)
+                {
+                    val extension = path.substringAfterLast(".","")
+                    inputStream = if (path.contains("/")) {
+                        File(path).inputStream()
+                    } else {
+                        context.assets.open(path)
+                    }
                 }
+                else if (file != null)
+                {
+                    inputStream = File(file.uri)
+                }
+
+                if (extension == "sec")
+                {
+                    val password = config.importBackupPassword
+                    if(password == "")
+                    {
+                        errorPassword = true
+                        throw Exception("No password provided")
+                    }
+
+                    try {
+                            BufferedInputStream(inputStream).use { raw ->
+                                val salt = ByteArray(16)
+                                val prefix = ByteArray(16)
+                                readBuffer(raw, salt)
+                                readBuffer(raw, prefix)
+                                val keyFactory: SecretKeyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
+                                val keySpec: KeySpec = PBEKeySpec(password.toCharArray(), salt, KEY_ITERATIONS, KEY_LENGTH)
+                                val secret: SecretKey = keyFactory.generateSecret(keySpec)
+                                val cipher: Cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+                                val iv = IvParameterSpec(prefix)
+                                cipher.init(Cipher.DECRYPT_MODE, secret, iv)
+                                inputStream = CipherInputStream(raw, cipher)
+                            }
+                    }
+                    catch (e: Exception)
+                    {
+                        throw Exception("Error while decrypting backup, please check your password.")
+                    }
+                }
+
+
 
                 inputStream.bufferedReader().use { reader ->
                     val json = reader.readText()
@@ -70,6 +138,7 @@ class MessagesImporter(private val context: Context) {
                 when {
                     messagesImported == 0 -> IMPORT_FAIL
                     messagesFailed > 0 -> IMPORT_PARTIAL
+                    errorPassword -> NO_PASSWORD_PROVIDED
                     else -> IMPORT_OK
                 }
             )

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesImporter.kt
@@ -1,8 +1,6 @@
 package com.simplemobiletools.smsmessenger.helpers
 
 import android.content.Context
-import android.provider.Telephony.*
-import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.simplemobiletools.commons.extensions.showErrorToast

--- a/app/src/main/res/layout/dialog_export_messages.xml
+++ b/app/src/main/res/layout/dialog_export_messages.xml
@@ -49,6 +49,24 @@
             android:textSize="@dimen/normal_text_size"
             tools:text="Messages" />
 
+        <com.simplemobiletools.commons.views.MyTextView
+            android:id="@+id/export_messages_password_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/small_margin"
+            android:text="@string/password_leave_blank_if_not_needed"
+            android:textSize="@dimen/smaller_text_size" />
+
+        <com.simplemobiletools.commons.views.MyEditText
+            android:id="@+id/export_messages_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/activity_margin"
+            android:paddingTop="@dimen/normal_margin"
+            android:paddingEnd="@dimen/small_margin"
+            android:textSize="@dimen/normal_text_size"
+            tools:text="Password" />
+
         <com.simplemobiletools.commons.views.MyAppCompatCheckbox
             android:id="@+id/export_sms_checkbox"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_import_messages.xml
+++ b/app/src/main/res/layout/dialog_import_messages.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/import_messages_scrollview"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -12,6 +13,24 @@
         android:paddingStart="@dimen/activity_margin"
         android:paddingTop="@dimen/activity_margin"
         android:paddingEnd="@dimen/activity_margin">
+
+        <com.simplemobiletools.commons.views.MyTextView
+            android:id="@+id/import_messages_password_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/small_margin"
+            android:text="@string/password_leave_blank_if_not_needed"
+            android:textSize="@dimen/smaller_text_size" />
+
+        <com.simplemobiletools.commons.views.MyEditText
+            android:id="@+id/import_messages_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/activity_margin"
+            android:paddingTop="@dimen/normal_margin"
+            android:paddingEnd="@dimen/small_margin"
+            android:textSize="@dimen/normal_text_size"
+            tools:text="Password" />
 
         <com.simplemobiletools.commons.views.MyAppCompatCheckbox
             android:id="@+id/import_sms_checkbox"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="send_long_message_mms">Send long messages as MMS</string>
     <!-- Export / Import -->
     <string name="messages">Messages</string>
+    <string name="password">Password</string>
     <string name="export_messages">Export messages</string>
     <string name="export_sms">Export SMS</string>
     <string name="export_mms">Export MMS</string>
@@ -92,6 +93,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="password_leave_blank_if_not_needed">Password (leave blank if not needed)</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res


### PR DESCRIPTION
NOTE : This is a work in progress. It is working, but some cleanup is needed, and I need to test it with a great amount of data.

Since exporting messages saves them into a json. It would be easy to grep a bunch of phone number, messages and mms, so I thought of adding this. It is completely based on FairEmail implementation. 

* It won't affect older backup, and new backup can be created w/o a password.

To encrypt the backup, simply input a password on the export dialog. Extension will be changed to .json to .sec by default. 
To decrypt, put the same password you provided at first.
