### PR TITLE
handle sending group SMS

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -829,7 +829,7 @@ class ThreadActivity : SimpleActivity() {
             transaction.setExplicitBroadcastForDeliveredSms(deliveredIntent)
 
             refreshedSinceSent = false
-            transaction.sendNewMessage(message, threadId)
+            transaction.sendNewMessage(message)
             thread_type_message.setText("")
             attachmentSelections.clear()
             thread_attachments_holder.beGone()

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -103,10 +103,13 @@ fun Context.getMessages(threadId: Long, getImageResolutions: Boolean): ArrayList
         val thread = cursor.getLongValue(Sms.THREAD_ID)
         val subscriptionId = cursor.getIntValue(Sms.SUBSCRIPTION_ID)
         val status = cursor.getIntValue(Sms.STATUS)
-        val phoneNumber = PhoneNumber(senderNumber, 0, "", senderNumber)
-        val participant = SimpleContact(0, 0, senderName, photoUri, arrayListOf(phoneNumber), ArrayList(), ArrayList())
+        val participants = senderNumber.split(" ").filter { it.areDigitsOnly() }.map { number ->
+            val phoneNumber = PhoneNumber(number, 0, "", number)
+            val participantPhoto = getNameAndPhotoFromPhoneNumber(number)
+            SimpleContact(0, 0, participantPhoto.name, photoUri, arrayListOf(phoneNumber), ArrayList(), ArrayList())
+        }
         val isMMS = false
-        val message = Message(id, body, type, status, arrayListOf(participant), date, read, thread, isMMS, null, senderName, photoUri, subscriptionId)
+        val message = Message(id, body, type, status, ArrayList(participants), date, read, thread, isMMS, null, senderName, photoUri, subscriptionId)
         messages.add(message)
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -103,7 +103,7 @@ fun Context.getMessages(threadId: Long, getImageResolutions: Boolean): ArrayList
         val thread = cursor.getLongValue(Sms.THREAD_ID)
         val subscriptionId = cursor.getIntValue(Sms.SUBSCRIPTION_ID)
         val status = cursor.getIntValue(Sms.STATUS)
-        val participants = senderNumber.split(" ").filter { it.areDigitsOnly() }.map { number ->
+        val participants = senderNumber.split(" ").map { number ->
             val phoneNumber = PhoneNumber(number, 0, "", number)
             val participantPhoto = getNameAndPhotoFromPhoneNumber(number)
             SimpleContact(0, 0, participantPhoto.name, photoUri, arrayListOf(phoneNumber), ArrayList(), ArrayList())

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/DirectReplyReceiver.kt
@@ -35,7 +35,7 @@ class DirectReplyReceiver : BroadcastReceiver() {
             transaction.setExplicitBroadcastForSentSms(smsSentIntent)
             transaction.setExplicitBroadcastForDeliveredSms(deliveredIntent)
 
-            transaction.sendNewMessage(message, threadId)
+            transaction.sendNewMessage(message)
         } catch (e: Exception) {
             context.showErrorToast(e)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/services/HeadlessSmsSendService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/services/HeadlessSmsSendService.kt
@@ -30,7 +30,7 @@ class HeadlessSmsSendService : Service() {
             transaction.setExplicitBroadcastForSentSms(smsSentIntent)
             transaction.setExplicitBroadcastForDeliveredSms(deliveredIntent)
 
-            transaction.sendNewMessage(message, getThreadId(number))
+            transaction.sendNewMessage(message)
         } catch (ignored: Exception) {
         }
 


### PR DESCRIPTION
# Notes
- in `Context.getMessages`, split the sender number by spaces " " to get each contact.
- apply update in the `android-smsmms` library - do not pass `threadId` in `Transaction.sendNewMessage`
- the `android-smsmms` library should be update after merging [this PR ](https://github.com/tibbi/android-smsmms/pull/1)

https://user-images.githubusercontent.com/25648077/166129734-8283e7e4-5c08-4845-a886-eabacd462d78.mp4


