### PR TITLE
Fix scroll position resetting on refresh

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -227,6 +227,11 @@ class ThreadActivity : SimpleActivity() {
                 ArrayList()
             }
 
+            messages.sortBy { it.date }
+            if (messages.size > MESSAGES_LIMIT) {
+                messages = ArrayList(messages.takeLast(MESSAGES_LIMIT))
+            }
+
             setupParticipants()
             setupAdapter()
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Config.kt
@@ -3,7 +3,6 @@ package com.simplemobiletools.smsmessenger.helpers
 import android.content.Context
 import com.simplemobiletools.commons.helpers.BaseConfig
 import com.simplemobiletools.smsmessenger.models.Conversation
-import java.util.HashSet
 
 class Config(context: Context) : BaseConfig(context) {
     companion object {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/models/ThreadDateTime.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/models/ThreadDateTime.kt
@@ -1,3 +1,3 @@
 package com.simplemobiletools.smsmessenger.models
 
-open class ThreadDateTime(val date: Int, val simID: String) : ThreadItem()
+data class ThreadDateTime(val date: Int, val simID: String) : ThreadItem()


### PR DESCRIPTION
Task description:
If you open a conversation with many messages and scroll up quickly after opening, once the messages get refetched, the scroll position returns to the bottom. We should keep the scroll position, especially if no new messages are found.