### PR TITLE
Respect default SMS SIM setting

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -573,7 +573,11 @@ class ThreadActivity : SimpleActivity() {
         val userPreferredSimIdx = availableSIMs.indexOfFirstOrNull { it.subscriptionId == userPreferredSimId }
 
         val lastMessage = messages.lastOrNull()
-        val senderPreferredSimIdx = availableSIMs.indexOfFirstOrNull { it.subscriptionId == lastMessage?.subscriptionId }
+        val senderPreferredSimIdx = if (lastMessage?.isReceivedMessage() == true) {
+            availableSIMs.indexOfFirstOrNull { it.subscriptionId == lastMessage.subscriptionId }
+        } else {
+            null
+        }
 
         val defaultSmsSubscriptionId = SmsManager.getDefaultSmsSubscriptionId()
         val systemPreferredSimIdx = if (defaultSmsSubscriptionId >= 0) {
@@ -583,7 +587,7 @@ class ThreadActivity : SimpleActivity() {
             null
         }
 
-        return userPreferredSimIdx ?: senderPreferredSimIdx ?: systemPreferredSimIdx ?: 0
+        return senderPreferredSimIdx ?: userPreferredSimIdx ?: systemPreferredSimIdx ?: 0
     }
 
     private fun blockNumber() {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -16,7 +16,6 @@ import android.provider.Telephony
 import android.telephony.SmsManager
 import android.telephony.SmsMessage
 import android.telephony.SubscriptionInfo
-import android.telephony.SubscriptionManager
 import android.text.TextUtils
 import android.util.TypedValue
 import android.view.Gravity
@@ -587,7 +586,7 @@ class ThreadActivity : SimpleActivity() {
             null
         }
 
-        return senderPreferredSimIdx ?: userPreferredSimIdx ?: systemPreferredSimIdx ?: 0
+        return userPreferredSimIdx ?: senderPreferredSimIdx ?: systemPreferredSimIdx ?: 0
     }
 
     private fun blockNumber() {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -709,7 +709,7 @@ class ThreadActivity : SimpleActivity() {
 
         val subscriptionIdToSimId = HashMap<Int, String>()
         subscriptionIdToSimId[-1] = "?"
-        SubscriptionManager.from(this).activeSubscriptionInfoList?.forEachIndexed { index, subscriptionInfo ->
+        subscriptionManagerCompat().activeSubscriptionInfoList?.forEachIndexed { index, subscriptionInfo ->
             subscriptionIdToSimId[subscriptionInfo.subscriptionId] = "${index + 1}"
         }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -53,7 +53,7 @@ class ThreadAdapter(
     private var fontSize = activity.getTextSize()
 
     @SuppressLint("MissingPermission")
-    private val hasMultipleSIMCards = (SubscriptionManager.from(activity).activeSubscriptionInfoList?.size ?: 0) > 1
+    private val hasMultipleSIMCards = (activity.subscriptionManagerCompat().activeSubscriptionInfoList?.size ?: 0) > 1
 
     init {
         setupDragListener(true)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -16,12 +16,14 @@ import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.RingtoneManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.provider.ContactsContract.PhoneLookup
 import android.provider.OpenableColumns
 import android.provider.Telephony.*
+import android.telephony.SubscriptionManager
 import android.text.TextUtils
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
@@ -991,5 +993,14 @@ fun Context.clearAllMessagesIfNeeded() {
             messagesDB.deleteAll()
         }
         config.wasDbCleared = true
+    }
+}
+
+fun Context.subscriptionManagerCompat(): SubscriptionManager {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        getSystemService(SubscriptionManager::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        SubscriptionManager.from(this)
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -16,7 +16,6 @@ import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.RingtoneManager
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -997,7 +996,7 @@ fun Context.clearAllMessagesIfNeeded() {
 }
 
 fun Context.subscriptionManagerCompat(): SubscriptionManager {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    return if (isMarshmallowPlus()) {
         getSystemService(SubscriptionManager::class.java)
     } else {
         @Suppress("DEPRECATION")

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/DirectReplyReceiver.kt
@@ -26,7 +26,7 @@ class DirectReplyReceiver : BroadcastReceiver() {
 
         val settings = context.getSendMessageSettings()
         if (address != null) {
-            val availableSIMs = SubscriptionManager.from(context).activeSubscriptionInfoList
+            val availableSIMs = context.subscriptionManagerCompat().activeSubscriptionInfoList
             if ((availableSIMs?.size ?: 0) > 1) {
                 val currentSIMCardIndex = context.config.getUseSIMIdAtNumber(address)
                 val wantedId = availableSIMs.getOrNull(currentSIMCardIndex)


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/378

Order of preference:
 1. SIM selected manually by the user is always preferred.
 2. SIM corresponding to the last received message's address.
 3. SIM selected as the default for SMS in android settings.

EDIT: Reorder preference as per the [latest commit](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/pull/431/commits/52e18200b8810225630bff388c4f47717769e52f)