### PR TITLE
Add a togglable option to prefer displaying nicknames over full names.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId "com.simplemobiletools.smsmessenger"
-        minSdkVersion 22
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode 62
         versionName "5.16.1"

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/SettingsActivity.kt
@@ -43,6 +43,7 @@ class SettingsActivity : SimpleActivity() {
         setupGroupMessageAsMMS()
         setupLockScreenVisibility()
         setupMMSFileSizeLimit()
+        setupDisplayNickname()
         updateTextColors(settings_nested_scrollview)
 
         if (blockedNumbersAtPause != -1 && blockedNumbersAtPause != getBlockedNumbers().hashCode()) {
@@ -195,6 +196,14 @@ class SettingsActivity : SimpleActivity() {
         settings_send_group_message_mms_holder.setOnClickListener {
             settings_send_group_message_mms.toggle()
             config.sendGroupMessageMMS = settings_send_group_message_mms.isChecked
+        }
+    }
+
+    private fun setupDisplayNickname() {
+        settings_display_nickname.isChecked = config.displayNickname
+        settings_display_nickname_holder.setOnClickListener {
+            settings_display_nickname.toggle()
+            config.displayNickname = settings_display_nickname.isChecked
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -550,22 +550,23 @@ fun Context.getNameAndPhotoFromPhoneNumber(number: String): NamePhoto {
 
                 var name = phoneLookupCursor.getStringValue(PhoneLookup.DISPLAY_NAME)
 
-                val contactsContractCursor = contentResolver.query(Data.CONTENT_URI,
-                    arrayOf(Nickname.NAME),
-                    Data.CONTACT_ID + " = ? AND " + Data.MIMETYPE + "= ?",
-                    arrayOf(contactId, Nickname.CONTENT_ITEM_TYPE),
-                    null
-                )
-                contactsContractCursor.use {
-                    if (contactsContractCursor?.moveToFirst() == true) {
-                        val nick = contactsContractCursor.getString(contactsContractCursor.getColumnIndexOrThrow(Nickname.NAME))
-                        if (nick != null && nick.isNotEmpty()) {
-                            name = nick
+                if (config.displayNickname) {
+                    val contactsContractCursor = contentResolver.query(Data.CONTENT_URI,
+                        arrayOf(Nickname.NAME),
+                        Data.CONTACT_ID + " = ? AND " + Data.MIMETYPE + "= ?",
+                        arrayOf(contactId, Nickname.CONTENT_ITEM_TYPE),
+                        null
+                    )
+                    contactsContractCursor.use {
+                        if (contactsContractCursor?.moveToFirst() == true) {
+                            val nick = contactsContractCursor.getString(contactsContractCursor.getColumnIndexOrThrow(Nickname.NAME))
+                            if (nick != null && nick.isNotEmpty()) {
+                                name = nick
+                            }
                         }
-
-                        return NamePhoto(name, photoUri)
                     }
                 }
+                return NamePhoto(name, photoUri)
             }
         }
     } catch (e: Exception) {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -528,7 +528,6 @@ fun Context.getSuggestedContacts(privateContacts: ArrayList<SimpleContact>): Arr
     return contacts
 }
 
-@RequiresApi(Build.VERSION_CODES.N)
 fun Context.getNameAndPhotoFromPhoneNumber(number: String): NamePhoto {
     if (!hasPermission(PERMISSION_READ_CONTACTS)) {
         return NamePhoto(number, null)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Config.kt
@@ -86,4 +86,8 @@ class Config(context: Context) : BaseConfig(context) {
     var wasDbCleared: Boolean
         get() = prefs.getBoolean(WAS_DB_CLEARED, false)
         set(wasDbCleared) = prefs.edit().putBoolean(WAS_DB_CLEARED, wasDbCleared).apply()
+
+    var displayNickname: Boolean
+        get() = prefs.getBoolean(DISPLAY_NICKNAME, false)
+        set(displayNickname) = prefs.edit().putBoolean(DISPLAY_NICKNAME, displayNickname).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/Constants.kt
@@ -30,6 +30,7 @@ const val IMPORT_MMS = "import_mms"
 const val WAS_DB_CLEARED = "was_db_cleared_2"
 const val EXTRA_VCARD_URI = "vcard"
 const val SCHEDULED_MESSAGE_ID = "scheduled_message_id"
+const val DISPLAY_NICKNAME = "display_nickname"
 
 private const val PATH = "com.simplemobiletools.smsmessenger.action."
 const val MARK_AS_READ = PATH + "mark_as_read"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -193,6 +193,21 @@
                         tools:text="@string/medium" />
 
                 </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/settings_display_nickname_holder"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ripple_bottom_corners"
+                    android:padding="@dimen/activity_margin">
+
+                    <com.simplemobiletools.commons.views.MyAppCompatCheckbox
+                        android:id="@+id/settings_display_nickname"
+                        style="@style/SettingsCheckboxStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_display_nickname" />
+                </RelativeLayout>
             </LinearLayout>
 
             <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="faq_2_text">MMS size is limited by carriers, you can try setting a smaller limit in the app settings.</string>
     <string name="faq_3_title">Does the app support scheduled messages?</string>
     <string name="faq_3_text">Yes, you can schedule messages to be sent in the future by long pressing the Send button and picking the desired date and time.</string>
+    <string name="settings_display_nickname">Prefer to display nicknames over full names</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res


### PR DESCRIPTION
This is my first time making an android contribution and working with Kotlin so I probably did some dumb things; please criticize.

Before toggling the feature the contact's full name is displayed:
![image](https://user-images.githubusercontent.com/14886022/200155884-b3f35315-1e3d-4444-a668-27389e43efb2.png)

The feature is toggled and the nickname field is displayed instead:
![image](https://user-images.githubusercontent.com/14886022/200155915-1d480f90-904c-4e70-a9d5-dd14b2f1f057.png)

Contacts without nicknames will display as normal (not shown).