### PR TITLE
Catch exception when updating subscription id

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -83,6 +83,7 @@ class ThreadActivity : SimpleActivity() {
     private var participants = ArrayList<SimpleContact>()
     private var privateContacts = ArrayList<SimpleContact>()
     private var messages = ArrayList<Message>()
+    private var lastMaxId = 0L
     private val availableSIMCards = ArrayList<SIMCard>()
     private var lastAttachmentUri: String? = null
     private var capturedImageUri: Uri? = null
@@ -131,6 +132,7 @@ class ThreadActivity : SimpleActivity() {
                     }
 
                     setupThread()
+                    storeLastMessageId()
                 }
             } else {
                 finish()
@@ -1289,7 +1291,6 @@ class ThreadActivity : SimpleActivity() {
             notificationManager.cancel(threadId.hashCode())
         }
 
-        val lastMaxId = messages.filterNot { it.isScheduled }.maxByOrNull { it.id }?.id ?: 0L
         val newThreadId = getThreadId(participants.getAddresses().toSet())
         val newMessages = getMessages(newThreadId, getImageResolutions = true, includeScheduledMessages = false)
 
@@ -1309,11 +1310,17 @@ class ThreadActivity : SimpleActivity() {
             maybeUpdateMessageSubId(latestMessage)
             messagesDB.insertOrIgnore(latestMessage)
         }
+        storeLastMessageId()
 
         setupAdapter()
         runOnUiThread {
             setupSIMSelector()
         }
+    }
+
+    private fun storeLastMessageId() {
+        lastMaxId = messages.filterNot { it.isScheduled }
+            .maxByOrNull { it.id }?.id ?: 0L
     }
 
     @SuppressLint("MissingPermission")

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -683,7 +683,11 @@ fun Context.updateMessageSubscriptionId(messageId: Long, subscriptionId: Int) {
     }
     val selection = "${Sms._ID} = ?"
     val selectionArgs = arrayOf(messageId.toString())
-    contentResolver.update(uri, contentValues, selection, selectionArgs)
+    try {
+        contentResolver.update(uri, contentValues, selection, selectionArgs)
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
 }
 
 fun Context.updateUnreadCountBadge(conversations: List<Conversation>) {


### PR DESCRIPTION
The subscription id will be updated on the next refresh call so it shouldn't break anything.