### PR TITLE
Add ability to change group names

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -141,6 +141,12 @@
             android:label="@string/contact_details"
             android:parentActivityName=".activities.ThreadActivity" />
 
+        <activity
+            android:name=".activities.ConversationDetailsActivity"
+            android:exported="false"
+            android:label="@string/conversation_details"
+            android:parentActivityName=".activities.ThreadActivity" />
+
         <service
             android:name=".services.HeadlessSmsSendService"
             android:exported="true"

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ConversationDetailsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ConversationDetailsActivity.kt
@@ -1,0 +1,87 @@
+package com.simplemobiletools.smsmessenger.activities
+
+import android.net.Uri
+import android.os.Bundle
+import android.provider.ContactsContract
+import androidx.core.content.res.ResourcesCompat
+import com.simplemobiletools.commons.extensions.adjustAlpha
+import com.simplemobiletools.commons.extensions.applyColorFilter
+import com.simplemobiletools.commons.extensions.getProperTextColor
+import com.simplemobiletools.commons.extensions.launchViewContactIntent
+import com.simplemobiletools.commons.helpers.NavigationIcon
+import com.simplemobiletools.commons.helpers.SimpleContactsHelper
+import com.simplemobiletools.commons.helpers.ensureBackgroundThread
+import com.simplemobiletools.commons.models.SimpleContact
+import com.simplemobiletools.smsmessenger.R
+import com.simplemobiletools.smsmessenger.adapters.ContactsAdapter
+import com.simplemobiletools.smsmessenger.dialogs.RenameConversationDialog
+import com.simplemobiletools.smsmessenger.extensions.conversationsDB
+import com.simplemobiletools.smsmessenger.extensions.getThreadParticipants
+import com.simplemobiletools.smsmessenger.extensions.renameConversation
+import com.simplemobiletools.smsmessenger.helpers.THREAD_ID
+import com.simplemobiletools.smsmessenger.models.Conversation
+import kotlinx.android.synthetic.main.activity_conversation_details.*
+
+class ConversationDetailsActivity : SimpleActivity() {
+
+    private var threadId: Long = 0L
+    private var conversation: Conversation? = null
+    private lateinit var participants: ArrayList<SimpleContact>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_conversation_details)
+
+        threadId = intent.getLongExtra(THREAD_ID, 0L)
+        ensureBackgroundThread {
+            conversation = conversationsDB.getConversationWithThreadId(threadId)
+            participants = getThreadParticipants(threadId, null)
+            runOnUiThread {
+                setupTextViews()
+                setupParticipants()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setupToolbar(conversation_details_toolbar, NavigationIcon.Arrow)
+    }
+
+    private fun setupTextViews() {
+        val textColor = getProperTextColor()
+        val headingColor = textColor.adjustAlpha(0.8f)
+
+        members_heading.setTextColor(headingColor)
+        conversation_name_heading.setTextColor(headingColor)
+        conversation_name.apply {
+            setTextColor(textColor)
+            ResourcesCompat.getDrawable(resources, R.drawable.ic_edit_vector, theme)?.apply {
+                applyColorFilter(textColor)
+                setCompoundDrawablesWithIntrinsicBounds(null, null, this, null)
+            }
+
+            text = conversation?.title
+            setOnClickListener {
+                RenameConversationDialog(this@ConversationDetailsActivity, conversation!!) { title ->
+                    text = title
+                    ensureBackgroundThread {
+                        conversation = renameConversation(conversation!!, newTitle = title)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun setupParticipants() {
+        val adapter = ContactsAdapter(this, participants, participants_recyclerview) {
+            val contact = it as SimpleContact
+            val lookupKey = SimpleContactsHelper(this).getContactLookupKey(contact.rawId.toString())
+            val publicUri = Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, lookupKey)
+            runOnUiThread {
+                launchViewContactIntent(publicUri)
+            }
+        }
+        participants_recyclerview.adapter = adapter
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ConversationDetailsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ConversationDetailsActivity.kt
@@ -1,24 +1,18 @@
 package com.simplemobiletools.smsmessenger.activities
 
-import android.net.Uri
 import android.os.Bundle
-import android.provider.ContactsContract
 import androidx.core.content.res.ResourcesCompat
 import com.simplemobiletools.commons.extensions.adjustAlpha
 import com.simplemobiletools.commons.extensions.applyColorFilter
 import com.simplemobiletools.commons.extensions.getProperTextColor
-import com.simplemobiletools.commons.extensions.launchViewContactIntent
 import com.simplemobiletools.commons.helpers.HIGHER_ALPHA
 import com.simplemobiletools.commons.helpers.NavigationIcon
-import com.simplemobiletools.commons.helpers.SimpleContactsHelper
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.commons.models.SimpleContact
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.adapters.ContactsAdapter
 import com.simplemobiletools.smsmessenger.dialogs.RenameConversationDialog
-import com.simplemobiletools.smsmessenger.extensions.conversationsDB
-import com.simplemobiletools.smsmessenger.extensions.getThreadParticipants
-import com.simplemobiletools.smsmessenger.extensions.renameConversation
+import com.simplemobiletools.smsmessenger.extensions.*
 import com.simplemobiletools.smsmessenger.helpers.THREAD_ID
 import com.simplemobiletools.smsmessenger.models.Conversation
 import kotlinx.android.synthetic.main.activity_conversation_details.*
@@ -77,10 +71,11 @@ class ConversationDetailsActivity : SimpleActivity() {
     private fun setupParticipants() {
         val adapter = ContactsAdapter(this, participants, participants_recyclerview) {
             val contact = it as SimpleContact
-            val lookupKey = SimpleContactsHelper(this).getContactLookupKey(contact.rawId.toString())
-            val publicUri = Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, lookupKey)
-            runOnUiThread {
-                launchViewContactIntent(publicUri)
+            val address = contact.phoneNumbers.first().normalizedNumber
+            getContactFromAddress(address) { simpleContact ->
+                if (simpleContact != null) {
+                    startContactDetailsIntent(simpleContact)
+                }
             }
         }
         participants_recyclerview.adapter = adapter

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ConversationDetailsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ConversationDetailsActivity.kt
@@ -8,6 +8,7 @@ import com.simplemobiletools.commons.extensions.adjustAlpha
 import com.simplemobiletools.commons.extensions.applyColorFilter
 import com.simplemobiletools.commons.extensions.getProperTextColor
 import com.simplemobiletools.commons.extensions.launchViewContactIntent
+import com.simplemobiletools.commons.helpers.HIGHER_ALPHA
 import com.simplemobiletools.commons.helpers.NavigationIcon
 import com.simplemobiletools.commons.helpers.SimpleContactsHelper
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
@@ -50,7 +51,7 @@ class ConversationDetailsActivity : SimpleActivity() {
 
     private fun setupTextViews() {
         val textColor = getProperTextColor()
-        val headingColor = textColor.adjustAlpha(0.8f)
+        val headingColor = textColor.adjustAlpha(HIGHER_ALPHA)
 
         members_heading.setTextColor(headingColor)
         conversation_name_heading.setTextColor(headingColor)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
@@ -257,9 +257,14 @@ class MainActivity : SimpleActivity() {
             }
 
             cachedConversations.forEach { cachedConv ->
-                val conv = conversations.find { it.threadId == cachedConv.threadId && !Conversation.areContentsTheSame(cachedConv, it) }
+                val conv = conversations.find {
+                    it.threadId == cachedConv.threadId && !Conversation.areContentsTheSame(cachedConv, it)
+                }
                 if (conv != null) {
-                    val conversation = conv.copy(date = maxOf(cachedConv.date, conv.date))
+                    val lastModified = maxOf(cachedConv.date, conv.date)
+                    val usesCustomTitle = cachedConv.usesCustomTitle
+                    val title = if (usesCustomTitle) cachedConv.title else conv.title
+                    val conversation = conv.copy(date = lastModified, title = title, usesCustomTitle = usesCustomTitle)
                     conversationsDB.insertOrUpdate(conversation)
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -154,6 +154,16 @@ class ThreadActivity : SimpleActivity() {
             thread_type_message.setText(smsDraft)
         }
         isActivityVisible = true
+
+        ensureBackgroundThread {
+            val newConv = conversationsDB.getConversationWithThreadId(threadId)
+            if (newConv != null) {
+                conversation = newConv
+                runOnUiThread {
+                    setupThreadTitle()
+                }
+            }
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -188,6 +188,7 @@ class ThreadActivity : SimpleActivity() {
         thread_toolbar.menu.apply {
             findItem(R.id.delete).isVisible = threadItems.isNotEmpty()
             findItem(R.id.rename_conversation).isVisible = participants.size > 1 && conversation != null
+            findItem(R.id.conversation_details).isVisible = participants.size > 1 && conversation != null
             findItem(R.id.block_number).title = addLockedLabelIfNeeded(R.string.block_number)
             findItem(R.id.block_number).isVisible = isNougatPlus()
             findItem(R.id.dial_number).isVisible = participants.size == 1
@@ -210,6 +211,7 @@ class ThreadActivity : SimpleActivity() {
                 R.id.block_number -> tryBlocking()
                 R.id.delete -> askConfirmDelete()
                 R.id.rename_conversation -> renameConversation()
+                R.id.conversation_details -> showConversationDetails()
                 R.id.add_number_to_contact -> addNumberToContact()
                 R.id.dial_number -> dialNumber()
                 R.id.manage_people -> managePeople()
@@ -848,6 +850,13 @@ class ThreadActivity : SimpleActivity() {
                     setupThreadTitle()
                 }
             }
+        }
+    }
+
+    private fun showConversationDetails() {
+        Intent(this, ConversationDetailsActivity::class.java).apply {
+            putExtra(THREAD_ID, threadId)
+            startActivity(this)
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -1286,31 +1286,6 @@ class ThreadActivity : SimpleActivity() {
         return participants
     }
 
-    fun startContactDetailsIntent(contact: SimpleContact) {
-        val simpleContacts = "com.simplemobiletools.contacts.pro"
-        val simpleContactsDebug = "com.simplemobiletools.contacts.pro.debug"
-        if (contact.rawId > 1000000 && contact.contactId > 1000000 && contact.rawId == contact.contactId &&
-            (isPackageInstalled(simpleContacts) || isPackageInstalled(simpleContactsDebug))
-        ) {
-            Intent().apply {
-                action = Intent.ACTION_VIEW
-                putExtra(CONTACT_ID, contact.rawId)
-                putExtra(IS_PRIVATE, true)
-                setPackage(if (isPackageInstalled(simpleContacts)) simpleContacts else simpleContactsDebug)
-                setDataAndType(ContactsContract.Contacts.CONTENT_LOOKUP_URI, "vnd.android.cursor.dir/person")
-                launchActivityIntent(this)
-            }
-        } else {
-            ensureBackgroundThread {
-                val lookupKey = SimpleContactsHelper(this).getContactLookupKey((contact).rawId.toString())
-                val publicUri = Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, lookupKey)
-                runOnUiThread {
-                    launchViewContactIntent(publicUri)
-                }
-            }
-        }
-    }
-
     fun saveMMS(mimeType: String, path: String) {
         hideKeyboard()
         lastAttachmentUri = path

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -283,7 +283,7 @@ class ThreadAdapter(
                 val contact = message.participants.first()
                 context.getContactFromAddress(contact.phoneNumbers.first().normalizedNumber) {
                     if (it != null) {
-                        (activity as ThreadActivity).startContactDetailsIntent(it)
+                        activity.startContactDetailsIntent(it)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/databases/MessagesDatabase.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/databases/MessagesDatabase.kt
@@ -17,7 +17,7 @@ import com.simplemobiletools.smsmessenger.models.Conversation
 import com.simplemobiletools.smsmessenger.models.Message
 import com.simplemobiletools.smsmessenger.models.MessageAttachment
 
-@Database(entities = [Conversation::class, Attachment::class, MessageAttachment::class, Message::class], version = 5)
+@Database(entities = [Conversation::class, Attachment::class, MessageAttachment::class, Message::class], version = 6)
 @TypeConverters(Converters::class)
 abstract class MessagesDatabase : RoomDatabase() {
 
@@ -42,6 +42,7 @@ abstract class MessagesDatabase : RoomDatabase() {
                             .addMigrations(MIGRATION_2_3)
                             .addMigrations(MIGRATION_3_4)
                             .addMigrations(MIGRATION_4_5)
+                            .addMigrations(MIGRATION_5_6)
                             .build()
                     }
                 }
@@ -94,6 +95,14 @@ abstract class MessagesDatabase : RoomDatabase() {
                 database.apply {
                     execSQL("ALTER TABLE messages ADD COLUMN is_scheduled INTEGER NOT NULL DEFAULT 0")
                     execSQL("ALTER TABLE conversations ADD COLUMN is_scheduled INTEGER NOT NULL DEFAULT 0")
+                }
+            }
+        }
+
+        private val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.apply {
+                    execSQL("ALTER TABLE conversations ADD COLUMN uses_custom_title INTEGER NOT NULL DEFAULT 0")
                 }
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/RenameConversationDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/RenameConversationDialog.kt
@@ -24,6 +24,7 @@ class RenameConversationDialog(
         val backgroundColor = activity.getProperBackgroundColor()
 
         val view = (activity.layoutInflater.inflate(R.layout.dialog_rename_conversation, null) as ViewGroup).apply {
+            rename_conv_info.setTextColor(textColor)
             rename_conv_input_layout.apply {
                 setColors(textColor, primaryColor, backgroundColor)
                 setBoxCornerRadiiResources(R.dimen.medium_margin, R.dimen.medium_margin, R.dimen.medium_margin, R.dimen.medium_margin)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/RenameConversationDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/RenameConversationDialog.kt
@@ -1,0 +1,62 @@
+package com.simplemobiletools.smsmessenger.dialogs
+
+import android.app.Activity
+import android.content.DialogInterface.BUTTON_POSITIVE
+import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.core.widget.doAfterTextChanged
+import com.simplemobiletools.commons.extensions.*
+import com.simplemobiletools.smsmessenger.R
+import com.simplemobiletools.smsmessenger.models.Conversation
+import kotlinx.android.synthetic.main.dialog_rename_conversation.view.*
+
+class RenameConversationDialog(
+    private val activity: Activity,
+    private val conversation: Conversation,
+    private val callback: (name: String) -> Unit,
+) {
+
+    private var dialog: AlertDialog? = null
+
+    init {
+        val textColor = activity.getProperTextColor()
+        val primaryColor = activity.getProperPrimaryColor()
+        val backgroundColor = activity.getProperBackgroundColor()
+
+        val view = (activity.layoutInflater.inflate(R.layout.dialog_rename_conversation, null) as ViewGroup).apply {
+            rename_conv_input_layout.apply {
+                setColors(textColor, primaryColor, backgroundColor)
+                setBoxCornerRadiiResources(R.dimen.medium_margin, R.dimen.medium_margin, R.dimen.medium_margin, R.dimen.medium_margin)
+            }
+            rename_conv_edit_text.apply {
+                setTextColor(textColor)
+                if (conversation.usesCustomTitle) {
+                    setText(conversation.title)
+                }
+                hint = conversation.title
+
+                doAfterTextChanged {
+                    dialog?.getButton(BUTTON_POSITIVE)?.isEnabled = !it.isNullOrEmpty()
+                }
+            }
+        }
+
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(R.string.ok, null)
+            .setNegativeButton(R.string.cancel, null)
+            .apply {
+                activity.setupDialogStuff(view, this, R.string.rename_conversation) { alertDialog ->
+                    dialog = alertDialog
+                    alertDialog.showKeyboard(view.rename_conv_edit_text)
+                    alertDialog.getButton(BUTTON_POSITIVE).apply {
+                        val newTitle = view.rename_conv_edit_text.text.toString()
+                        isEnabled = newTitle.isNotEmpty() && (newTitle != conversation.title)
+                        setOnClickListener {
+                            alertDialog.dismiss()
+                            callback(view.rename_conv_edit_text.text.toString())
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -1023,6 +1023,20 @@ fun Context.subscriptionManagerCompat(): SubscriptionManager {
     }
 }
 
+fun Context.renameConversation(conversation: Conversation, newTitle: String): Conversation {
+    require(conversation.isGroupConversation) {
+        "Can only rename group conversations."
+    }
+
+    val updatedConv = conversation.copy(title = newTitle, usesCustomTitle = true)
+    try {
+        conversationsDB.insertOrUpdate(updatedConv)
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+    return updatedConv
+}
+
 fun Context.createTemporaryThread(message: Message, threadId: Long = generateRandomId()) {
     val simpleContactHelper = SimpleContactsHelper(this)
     val addresses = message.participants.getAddresses()

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -1024,10 +1024,6 @@ fun Context.subscriptionManagerCompat(): SubscriptionManager {
 }
 
 fun Context.renameConversation(conversation: Conversation, newTitle: String): Conversation {
-    require(conversation.isGroupConversation) {
-        "Can only rename group conversations."
-    }
-
     val updatedConv = conversation.copy(title = newTitle, usesCustomTitle = true)
     try {
         conversationsDB.insertOrUpdate(updatedConv)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/models/Conversation.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/models/Conversation.kt
@@ -15,7 +15,8 @@ data class Conversation(
     @ColumnInfo(name = "photo_uri") var photoUri: String,
     @ColumnInfo(name = "is_group_conversation") var isGroupConversation: Boolean,
     @ColumnInfo(name = "phone_number") var phoneNumber: String,
-    @ColumnInfo(name = "is_scheduled") var isScheduled: Boolean = false
+    @ColumnInfo(name = "is_scheduled") var isScheduled: Boolean = false,
+    @ColumnInfo(name = "uses_custom_title") var usesCustomTitle: Boolean = false
 ) {
 
     companion object {

--- a/app/src/main/res/layout/activity_conversation_details.xml
+++ b/app/src/main/res/layout/activity_conversation_details.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/conversation_details_app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/conversation_details_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/color_primary"
+            app:title="@string/conversation_details"
+            app:titleTextAppearance="@style/AppTheme.ActionBar.TitleTextStyle" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/conversation_name_heading"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/normal_margin"
+        android:layout_marginTop="@dimen/activity_margin"
+        android:text="@string/conversation_name"
+        android:textSize="@dimen/normal_text_size"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/conversation_details_app_bar_layout" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/conversation_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/small_margin"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:drawableEnd="@drawable/ic_edit_vector"
+        android:ellipsize="end"
+        android:focusable="true"
+        android:maxLines="1"
+        android:paddingHorizontal="@dimen/normal_margin"
+        android:paddingVertical="@dimen/normal_margin"
+        android:text="@string/members"
+        android:textSize="@dimen/big_text_size"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/conversation_name_heading" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/members_heading"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/normal_margin"
+        android:layout_marginTop="@dimen/normal_margin"
+        android:text="@string/members"
+        android:textSize="@dimen/normal_text_size"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/conversation_name" />
+
+    <com.simplemobiletools.commons.views.MyRecyclerView
+        android:id="@+id/participants_recyclerview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/normal_margin"
+        android:overScrollMode="ifContentScrolls"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/members_heading"
+        tools:itemCount="3"
+        tools:listitem="@layout/item_contact_with_number" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_rename_conversation.xml
+++ b/app/src/main/res/layout/dialog_rename_conversation.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingVertical="@dimen/big_margin">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/rename_conv_info"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/big_margin"
+        android:paddingHorizontal="@dimen/tiny_margin"
+        android:text="@string/rename_conversation_warning"
+        app:layout_constraintBottom_toTopOf="@id/rename_conv_input_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.simplemobiletools.commons.views.MyTextInputLayout
+        android:id="@+id/rename_conv_input_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/big_margin"
+        android:layout_marginTop="@dimen/activity_margin"
+        android:hint="@string/conversation_name"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/rename_conv_info">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/rename_conv_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            android:maxLength="30"
+            android:maxLines="1" />
+
+    </com.simplemobiletools.commons.views.MyTextInputLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/cab_conversations.xml
+++ b/app/src/main/res/menu/cab_conversations.xml
@@ -29,6 +29,11 @@
         android:title="@string/copy_number_to_clipboard"
         app:showAsAction="never" />
     <item
+        android:id="@+id/rename_conversation"
+        android:icon="@drawable/ic_edit_vector"
+        android:title="@string/rename_conversation"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/cab_mark_as_read"
         android:showAsAction="never"
         android:title="@string/mark_as_read"

--- a/app/src/main/res/menu/menu_thread.xml
+++ b/app/src/main/res/menu/menu_thread.xml
@@ -19,6 +19,11 @@
         android:title="@string/add_person"
         app:showAsAction="always" />
     <item
+        android:id="@+id/rename_conversation"
+        android:icon="@drawable/ic_edit_vector"
+        android:title="@string/rename_conversation"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/add_number_to_contact"
         android:title="@string/add_number_to_contact"
         app:showAsAction="ifRoom" />

--- a/app/src/main/res/menu/menu_thread.xml
+++ b/app/src/main/res/menu/menu_thread.xml
@@ -24,6 +24,11 @@
         android:title="@string/rename_conversation"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/conversation_details"
+        android:icon="@drawable/ic_info_vector"
+        android:title="@string/conversation_details"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/add_number_to_contact"
         android:title="@string/add_number_to_contact"
         app:showAsAction="ifRoom" />


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/472

### Changes:
- Added ability to rename groups, name changes are lost on uninstall or when app storage is cleared. 
- Added conversation details page.

### Preview:
<img src="https://user-images.githubusercontent.com/36371707/203128681-c626e471-9d35-464f-ab77-fa1a5fad5ee7.png" width=200 /><img src="https://user-images.githubusercontent.com/36371707/203128421-33612274-c3d1-47a4-b532-0d9c59ac26fb.png" width=200 /> <img src="https://user-images.githubusercontent.com/36371707/203128500-50e9679f-059d-4fa9-afab-c9223912d879.png" width = 200 />
