### PR TITLE
Update conversation items on pin/unpin

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -283,6 +283,9 @@ class ConversationsAdapter(
             activity.config.removePinnedConversations(conversations)
         }
 
+        getSelectedItemPositions().forEach {
+            notifyItemChanged(it)
+        }
         refreshConversations()
     }
 


### PR DESCRIPTION
The pin drawable wasn't shown on the conversation until the next refresh, this PR fixes that.