### PR TITLE
Consider orientation when calculating InSampleSize during compression

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt
@@ -134,19 +134,15 @@ class ImageCompressor(private val context: Context) {
 
         private fun decodeSampledBitmapFromFile(imageFile: File, reqWidth: Int, reqHeight: Int): Bitmap {
             return BitmapFactory.Options().run {
-                inJustDecodeBounds = true
-                BitmapFactory.decodeFile(imageFile.absolutePath, this)
-
-                inSampleSize = calculateInSampleSize(this, reqWidth, reqHeight)
-
-                inJustDecodeBounds = false
+                inSampleSize = calculateInSampleSize(loadBitmap(imageFile), reqWidth, reqHeight)
                 BitmapFactory.decodeFile(imageFile.absolutePath, this)
             }
         }
 
-        private fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
+        private fun calculateInSampleSize(bitmap: Bitmap, reqWidth: Int, reqHeight: Int): Int {
             // Raw height and width of image
-            val (height: Int, width: Int) = options.run { outHeight to outWidth }
+            val height = bitmap.height
+            val width = bitmap.width
             var inSampleSize = 1
 
             if (height > reqHeight || width > reqWidth) {
@@ -165,11 +161,7 @@ class ImageCompressor(private val context: Context) {
         }
 
         fun isSatisfied(imageFile: File): Boolean {
-            return BitmapFactory.Options().run {
-                inJustDecodeBounds = true
-                BitmapFactory.decodeFile(imageFile.absolutePath, this)
-                calculateInSampleSize(this, width, height) <= 1
-            }
+            return calculateInSampleSize(loadBitmap(imageFile), width, height) <= 1
         }
 
         fun satisfy(imageFile: File): File {


### PR DESCRIPTION
The current factor matches what's inside of calculateInSampleSize
which causes the resolution check to be bypassed. So for larger files,
there's more potentially it can't compress it enough because you have to
rely entirely on quality decrease compression.

### Details

[`loadBitmap`](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/blob/master/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt#L94-L108) pulls the file through some orientation code and returns a properly orient Bitmap. With this Bitmap, we use it to determine [width and height](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/blob/master/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt#L46) for the `ResolutionConstraint`.

The `ResolutionConstraints` tries to check [`InSampleSize`](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/blob/master/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt#L46) by passing the BitmapOptions in, which does NOT consider orientation. As a result, when the calculation [pulls width and height](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/blob/master/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt#L149) from the file, it pulls it reversed b/c the options are considering orientation.

I assume this isn't a problem on most devices b/c they handle Exif data properly. I'm testing on a Samsung A13 and all portraits images have this problem and ultimetely fail compression b/c the code for `ResolutionConstraint` is never run b/c [`calculateInSampleSize`](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/blob/master/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/ImageCompressor.kt#L171) always returns `1` when the width and height are flipped on a large image.

Closes https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/511

#### Logs from portrait photo
<img width="544" alt="Screen Shot 2022-11-28 at 9 46 44 PM" src="https://user-images.githubusercontent.com/744212/204554569-48e7a1b3-6daf-44c8-94a7-abcbcc505646.png">

#### Logs from landscape photo
<img width="536" alt="Screen Shot 2022-11-28 at 9 47 15 PM" src="https://user-images.githubusercontent.com/744212/204554625-6268f793-5366-4209-b5c9-1f53c0d08800.png">
