### PR TITLE
Improve and organise notification related code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation "me.leolin:ShortcutBadger:1.1.22"
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.googlecode.ez-vcard:ez-vcard:0.11.3'
+    implementation 'androidx.lifecycle:lifecycle-process:2.5.1'
 
     kapt "androidx.room:room-compiler:2.4.3"
     implementation "androidx.room:room-runtime:2.4.3"

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -40,7 +40,9 @@ class ConversationsAdapter(
 
     init {
         setupDragListener(true)
-        fetchDrafts(drafts)
+        ensureBackgroundThread {
+            fetchDrafts(drafts)
+        }
         setHasStableIds(true)
 
         registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
@@ -314,11 +316,15 @@ class ConversationsAdapter(
     }
 
     fun updateDrafts() {
-        val newDrafts = HashMap<Long, String?>()
-        fetchDrafts(newDrafts)
-        if (drafts.hashCode() != newDrafts.hashCode()) {
-            drafts = newDrafts
-            notifyDataSetChanged()
+        ensureBackgroundThread {
+            val newDrafts = HashMap<Long, String?>()
+            fetchDrafts(newDrafts)
+            if (drafts.hashCode() != newDrafts.hashCode()) {
+                drafts = newDrafts
+                activity.runOnUiThread {
+                    notifyDataSetChanged()
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ConversationsAdapter.kt
@@ -1,5 +1,6 @@
 package com.simplemobiletools.smsmessenger.adapters
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Typeface
 import android.os.Parcelable
@@ -31,8 +32,9 @@ import com.simplemobiletools.smsmessenger.models.Conversation
 import kotlinx.android.synthetic.main.item_conversation.view.*
 
 class ConversationsAdapter(
-    activity: SimpleActivity, recyclerView: MyRecyclerView, itemClick: (Any) -> Unit
-) : MyRecyclerViewListAdapter<Conversation>(activity, recyclerView, ConversationDiffCallback(), itemClick), RecyclerViewFastScroller.OnPopupTextUpdate {
+    activity: SimpleActivity, recyclerView: MyRecyclerView, onRefresh: () -> Unit, itemClick: (Any) -> Unit
+) : MyRecyclerViewListAdapter<Conversation>(activity, recyclerView, ConversationDiffCallback(), itemClick, onRefresh),
+    RecyclerViewFastScroller.OnPopupTextUpdate {
     private var fontSize = activity.getTextSize()
     private var drafts = HashMap<Long, String?>()
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.Typeface
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.util.Size
@@ -18,7 +19,6 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.FitCenter
-import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
@@ -291,7 +291,20 @@ class ThreadAdapter(
             thread_message_body.setLinkTextColor(context.getProperPrimaryColor())
 
             if (!activity.isFinishing && !activity.isDestroyed) {
-                SimpleContactsHelper(context).loadContactImage(message.senderPhotoUri, thread_message_sender_photo, message.senderName)
+                val contactLetterIcon = SimpleContactsHelper(context).getContactLetterIcon(message.senderName)
+                val placeholder = BitmapDrawable(context.resources, contactLetterIcon)
+
+                val options = RequestOptions()
+                    .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
+                    .error(placeholder)
+                    .centerCrop()
+
+                Glide.with(context)
+                    .load(message.senderPhotoUri)
+                    .placeholder(placeholder)
+                    .apply(options)
+                    .apply(RequestOptions.circleCropTransform())
+                    .into(thread_message_sender_photo)
             }
         }
     }
@@ -341,7 +354,6 @@ class ThreadAdapter(
 
             var builder = Glide.with(context)
                 .load(uri)
-                .transition(DrawableTransitionOptions.withCrossFade())
                 .apply(options)
                 .listener(object : RequestListener<Drawable> {
                     override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<Drawable>?, isFirstResource: Boolean): Boolean {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/NotificationHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/NotificationHelper.kt
@@ -152,7 +152,9 @@ class NotificationHelper(private val context: Context) {
                 .setLegacyStreamType(AudioManager.STREAM_NOTIFICATION)
                 .build()
 
-            NotificationChannel(NOTIFICATION_CHANNEL, name, IMPORTANCE_HIGH).apply {
+            val id = NOTIFICATION_CHANNEL
+            val importance = IMPORTANCE_HIGH
+            NotificationChannel(id, name, importance).apply {
                 setBypassDnd(false)
                 enableLights(true)
                 setSound(soundUri, audioAttributes)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/NotificationHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/NotificationHelper.kt
@@ -170,7 +170,9 @@ class NotificationHelper(private val context: Context) {
                 .setName(name)
                 .setKey(address)
                 .build()
-        } else null
+        } else {
+            null
+        }
 
         return NotificationCompat.MessagingStyle(user).also { style ->
             getOldMessages(notificationId).forEach {
@@ -188,7 +190,7 @@ class NotificationHelper(private val context: Context) {
         val currentNotification = notificationManager.activeNotifications.find { it.id == notificationId }
         return if (currentNotification != null) {
             val activeStyle = NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(currentNotification.notification)
-            return activeStyle?.messages.orEmpty()
+            activeStyle?.messages.orEmpty()
         } else {
             emptyList()
         }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/NotificationHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/NotificationHelper.kt
@@ -119,7 +119,7 @@ class NotificationHelper(private val context: Context) {
     fun showSendingFailedNotification(recipientName: String, threadId: Long) {
         maybeCreateChannel(name = context.getString(R.string.message_not_sent_short))
 
-        val notificationId = threadId.hashCode()
+        val notificationId = generateRandomId().hashCode()
         val intent = Intent(context, ThreadActivity::class.java).apply {
             putExtra(THREAD_ID, threadId)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/NotificationHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/NotificationHelper.kt
@@ -1,0 +1,194 @@
+package com.simplemobiletools.smsmessenger.helpers
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager.IMPORTANCE_HIGH
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.media.AudioAttributes
+import android.media.AudioManager
+import android.media.RingtoneManager
+import androidx.core.app.NotificationCompat
+import androidx.core.app.Person
+import androidx.core.app.RemoteInput
+import com.simplemobiletools.commons.extensions.getProperPrimaryColor
+import com.simplemobiletools.commons.extensions.notificationManager
+import com.simplemobiletools.commons.helpers.SimpleContactsHelper
+import com.simplemobiletools.commons.helpers.isNougatPlus
+import com.simplemobiletools.commons.helpers.isOreoPlus
+import com.simplemobiletools.smsmessenger.R
+import com.simplemobiletools.smsmessenger.activities.ThreadActivity
+import com.simplemobiletools.smsmessenger.extensions.config
+import com.simplemobiletools.smsmessenger.receivers.DirectReplyReceiver
+import com.simplemobiletools.smsmessenger.receivers.MarkAsReadReceiver
+
+class NotificationHelper(private val context: Context) {
+
+    private val notificationManager = context.notificationManager
+    private val soundUri get() = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+    private val user = Person.Builder()
+        .setName(context.getString(R.string.me))
+        .build()
+
+    @SuppressLint("NewApi")
+    fun showMessageNotification(address: String, body: String, threadId: Long, bitmap: Bitmap?, sender: String?, alertOnlyOnce: Boolean = false) {
+        maybeCreateChannel(name = context.getString(R.string.channel_received_sms))
+
+        val notificationId = threadId.hashCode()
+        val contentIntent = Intent(context, ThreadActivity::class.java).apply {
+            putExtra(THREAD_ID, threadId)
+        }
+        val contentPendingIntent =
+            PendingIntent.getActivity(context, notificationId, contentIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+
+        val markAsReadIntent = Intent(context, MarkAsReadReceiver::class.java).apply {
+            action = MARK_AS_READ
+            putExtra(THREAD_ID, threadId)
+        }
+        val markAsReadPendingIntent =
+            PendingIntent.getBroadcast(context, notificationId, markAsReadIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+
+        var replyAction: NotificationCompat.Action? = null
+        if (isNougatPlus()) {
+            val replyLabel = context.getString(R.string.reply)
+            val remoteInput = RemoteInput.Builder(REPLY)
+                .setLabel(replyLabel)
+                .build()
+
+            val replyIntent = Intent(context, DirectReplyReceiver::class.java).apply {
+                putExtra(THREAD_ID, threadId)
+                putExtra(THREAD_NUMBER, address)
+            }
+
+            val replyPendingIntent =
+                PendingIntent.getBroadcast(
+                    context.applicationContext,
+                    notificationId,
+                    replyIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                )
+            replyAction = NotificationCompat.Action.Builder(R.drawable.ic_send_vector, replyLabel, replyPendingIntent)
+                .addRemoteInput(remoteInput)
+                .build()
+        }
+
+        val largeIcon = bitmap ?: if (sender != null) {
+            SimpleContactsHelper(context).getContactLetterIcon(sender)
+        } else {
+            null
+        }
+        val builder = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL).apply {
+            when (context.config.lockScreenVisibilitySetting) {
+                LOCK_SCREEN_SENDER_MESSAGE -> {
+                    setLargeIcon(largeIcon)
+                    setStyle(getMessagesStyle(address, body, notificationId, sender))
+                }
+                LOCK_SCREEN_SENDER -> {
+                    setContentTitle(sender)
+                    setLargeIcon(largeIcon)
+                    val summaryText = context.getString(R.string.new_message)
+                    setStyle(NotificationCompat.BigTextStyle().setSummaryText(summaryText).bigText(body))
+                }
+            }
+
+            color = context.getProperPrimaryColor()
+            setSmallIcon(R.drawable.ic_messenger)
+            setContentIntent(contentPendingIntent)
+            priority = NotificationCompat.PRIORITY_MAX
+            setDefaults(Notification.DEFAULT_LIGHTS)
+            setCategory(Notification.CATEGORY_MESSAGE)
+            setAutoCancel(true)
+            setOnlyAlertOnce(alertOnlyOnce)
+            setSound(soundUri, AudioManager.STREAM_NOTIFICATION)
+        }
+
+        if (replyAction != null && context.config.lockScreenVisibilitySetting == LOCK_SCREEN_SENDER_MESSAGE) {
+            builder.addAction(replyAction)
+        }
+
+        builder.addAction(R.drawable.ic_check_vector, context.getString(R.string.mark_as_read), markAsReadPendingIntent)
+            .setChannelId(NOTIFICATION_CHANNEL)
+
+        notificationManager.notify(notificationId, builder.build())
+    }
+
+    @SuppressLint("NewApi")
+    fun showSendingFailedNotification(recipientName: String, threadId: Long) {
+        maybeCreateChannel(name = context.getString(R.string.message_not_sent_short))
+
+        val notificationId = threadId.hashCode()
+        val intent = Intent(context, ThreadActivity::class.java).apply {
+            putExtra(THREAD_ID, threadId)
+        }
+        val contentPendingIntent = PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+
+        val summaryText = String.format(context.getString(R.string.message_sending_error), recipientName)
+        val largeIcon = SimpleContactsHelper(context).getContactLetterIcon(recipientName)
+        val builder = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL)
+            .setContentTitle(context.getString(R.string.message_not_sent_short))
+            .setContentText(summaryText)
+            .setColor(context.getProperPrimaryColor())
+            .setSmallIcon(R.drawable.ic_messenger)
+            .setLargeIcon(largeIcon)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(summaryText))
+            .setContentIntent(contentPendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_MAX)
+            .setDefaults(Notification.DEFAULT_LIGHTS)
+            .setCategory(Notification.CATEGORY_MESSAGE)
+            .setAutoCancel(true)
+            .setChannelId(NOTIFICATION_CHANNEL)
+
+        notificationManager.notify(notificationId, builder.build())
+    }
+
+    private fun maybeCreateChannel(name: String) {
+        if (isOreoPlus()) {
+            val audioAttributes = AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .setLegacyStreamType(AudioManager.STREAM_NOTIFICATION)
+                .build()
+
+            NotificationChannel(NOTIFICATION_CHANNEL, name, IMPORTANCE_HIGH).apply {
+                setBypassDnd(false)
+                enableLights(true)
+                setSound(soundUri, audioAttributes)
+                enableVibration(true)
+                notificationManager.createNotificationChannel(this)
+            }
+        }
+    }
+
+    private fun getMessagesStyle(address: String, body: String, notificationId: Int, name: String?): NotificationCompat.MessagingStyle {
+        val sender = if (name != null) {
+            Person.Builder()
+                .setName(name)
+                .setKey(address)
+                .build()
+        } else null
+
+        return NotificationCompat.MessagingStyle(user).also { style ->
+            getOldMessages(notificationId).forEach {
+                style.addMessage(it)
+            }
+            val newMessage = NotificationCompat.MessagingStyle.Message(body, System.currentTimeMillis(), sender)
+            style.addMessage(newMessage)
+        }
+    }
+
+    private fun getOldMessages(notificationId: Int): List<NotificationCompat.MessagingStyle.Message> {
+        if (!isNougatPlus()) {
+            return emptyList()
+        }
+        val currentNotification = notificationManager.activeNotifications.find { it.id == notificationId }
+        return if (currentNotification != null) {
+            val activeStyle = NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(currentNotification.notification)
+            return activeStyle?.messages.orEmpty()
+        } else {
+            emptyList()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/DirectReplyReceiver.kt
@@ -39,7 +39,7 @@ class DirectReplyReceiver : BroadcastReceiver() {
             ensureBackgroundThread {
                 try {
                     context.sendMessage(body, listOf(address), subscriptionId, emptyList())
-                    val message = context.getMessages(threadId, getImageResolutions = false, includeScheduledMessages = false, limit = 1).firstOrNull()
+                    val message = context.getMessages(threadId, getImageResolutions = false, includeScheduledMessages = false, limit = 1).lastOrNull()
                     if (message != null) {
                         context.messagesDB.insertOrUpdate(message)
                     }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsReceiver.kt
@@ -3,13 +3,9 @@ package com.simplemobiletools.smsmessenger.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
 import android.os.Handler
 import android.os.Looper
 import android.provider.Telephony
-import com.bumptech.glide.Glide
-import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.bumptech.glide.request.RequestOptions
 import com.simplemobiletools.commons.extensions.baseConfig
 import com.simplemobiletools.commons.extensions.getMyContactsCursor
 import com.simplemobiletools.commons.extensions.isNumberBlocked
@@ -17,7 +13,6 @@ import com.simplemobiletools.commons.helpers.SimpleContactsHelper
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import com.simplemobiletools.commons.models.PhoneNumber
 import com.simplemobiletools.commons.models.SimpleContact
-import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.extensions.*
 import com.simplemobiletools.smsmessenger.helpers.refreshMessages
 import com.simplemobiletools.smsmessenger.models.Message
@@ -63,7 +58,7 @@ class SmsReceiver : BroadcastReceiver() {
         context: Context, address: String, subject: String, body: String, date: Long, read: Int, threadId: Long, type: Int, subscriptionId: Int, status: Int
     ) {
         val photoUri = SimpleContactsHelper(context).getPhotoUriFromPhoneNumber(address)
-        val bitmap = getPhotoForNotification(photoUri, context)
+        val bitmap = context.getNotificationBitmap(photoUri)
         Handler(Looper.getMainLooper()).post {
             if (!context.isNumberBlocked(address)) {
                 val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
@@ -95,29 +90,6 @@ class SmsReceiver : BroadcastReceiver() {
 
                 context.showReceivedMessageNotification(address, body, threadId, bitmap)
             }
-        }
-    }
-
-    private fun getPhotoForNotification(photoUri: String, context: Context): Bitmap? {
-        val size = context.resources.getDimension(R.dimen.notification_large_icon_size).toInt()
-        if (photoUri.isEmpty()) {
-            return null
-        }
-
-        val options = RequestOptions()
-            .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
-            .centerCrop()
-
-        return try {
-            Glide.with(context)
-                .asBitmap()
-                .load(photoUri)
-                .apply(options)
-                .apply(RequestOptions.circleCropTransform())
-                .into(size, size)
-                .get()
-        } catch (e: Exception) {
-            null
         }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsStatusSentReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsStatusSentReceiver.kt
@@ -1,5 +1,6 @@
 package com.simplemobiletools.smsmessenger.receivers
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -19,11 +20,13 @@ class SmsStatusSentReceiver : SentReceiver() {
             val uri = Uri.parse(intent.getStringExtra("message_uri"))
             val messageId = uri?.lastPathSegment?.toLong() ?: 0L
             ensureBackgroundThread {
-                val type = if (intent.extras!!.containsKey("errorCode")) {
+                if (intent.extras!!.containsKey("errorCode")) {
                     showSendingFailedNotification(context, messageId)
-                    Telephony.Sms.MESSAGE_TYPE_FAILED
-                } else {
+                }
+                val type = if (receiverResultCode == Activity.RESULT_OK) {
                     Telephony.Sms.MESSAGE_TYPE_SENT
+                } else {
+                    Telephony.Sms.MESSAGE_TYPE_FAILED
                 }
 
                 context.updateMessageType(messageId, type)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsStatusSentReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsStatusSentReceiver.kt
@@ -1,31 +1,15 @@
 package com.simplemobiletools.smsmessenger.receivers
 
-import android.annotation.SuppressLint
-import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.media.AudioAttributes
-import android.media.AudioManager
-import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.provider.Telephony
-import androidx.core.app.NotificationCompat
 import com.klinker.android.send_message.SentReceiver
 import com.simplemobiletools.commons.extensions.getMyContactsCursor
-import com.simplemobiletools.commons.extensions.getProperPrimaryColor
-import com.simplemobiletools.commons.helpers.SimpleContactsHelper
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
-import com.simplemobiletools.commons.helpers.isOreoPlus
-import com.simplemobiletools.smsmessenger.R
-import com.simplemobiletools.smsmessenger.activities.ThreadActivity
 import com.simplemobiletools.smsmessenger.extensions.*
-import com.simplemobiletools.smsmessenger.helpers.NOTIFICATION_CHANNEL
-import com.simplemobiletools.smsmessenger.helpers.THREAD_ID
 import com.simplemobiletools.smsmessenger.helpers.refreshMessages
 
 class SmsStatusSentReceiver : SentReceiver() {
@@ -59,61 +43,13 @@ class SmsStatusSentReceiver : SentReceiver() {
 
     private fun showSendingFailedNotification(context: Context, messageId: Long) {
         Handler(Looper.getMainLooper()).post {
-            val privateCursor = context.getMyContactsCursor(false, true)
+            val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
             ensureBackgroundThread {
                 val address = context.getMessageRecipientAddress(messageId)
                 val threadId = context.getThreadId(address)
-                val senderName = context.getNameFromAddress(address, privateCursor)
-                showNotification(context, senderName, threadId)
+                val recipientName = context.getNameFromAddress(address, privateCursor)
+                context.notificationHelper.showSendingFailedNotification(recipientName, threadId)
             }
         }
-    }
-
-    @SuppressLint("NewApi")
-    private fun showNotification(context: Context, recipientName: String, threadId: Long) {
-        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
-        if (isOreoPlus()) {
-            val audioAttributes = AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                .setLegacyStreamType(AudioManager.STREAM_NOTIFICATION)
-                .build()
-
-            val name = context.getString(R.string.message_not_sent_short)
-            val importance = NotificationManager.IMPORTANCE_HIGH
-            NotificationChannel(NOTIFICATION_CHANNEL, name, importance).apply {
-                setBypassDnd(false)
-                enableLights(true)
-                setSound(soundUri, audioAttributes)
-                enableVibration(true)
-                notificationManager.createNotificationChannel(this)
-            }
-        }
-
-        val intent = Intent(context, ThreadActivity::class.java).apply {
-            putExtra(THREAD_ID, threadId)
-        }
-
-        val pendingIntent = PendingIntent.getActivity(context, threadId.hashCode(), intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
-        val summaryText = String.format(context.getString(R.string.message_sending_error), recipientName)
-
-        val largeIcon = SimpleContactsHelper(context).getContactLetterIcon(recipientName)
-        val builder = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL)
-            .setContentTitle(context.getString(R.string.message_not_sent_short))
-            .setContentText(summaryText)
-            .setColor(context.getProperPrimaryColor())
-            .setSmallIcon(R.drawable.ic_messenger)
-            .setLargeIcon(largeIcon)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(summaryText))
-            .setContentIntent(pendingIntent)
-            .setPriority(NotificationCompat.PRIORITY_MAX)
-            .setDefaults(Notification.DEFAULT_LIGHTS)
-            .setCategory(Notification.CATEGORY_MESSAGE)
-            .setAutoCancel(true)
-            .setSound(soundUri, AudioManager.STREAM_NOTIFICATION)
-            .setChannelId(NOTIFICATION_CHANNEL)
-
-        notificationManager.notify(threadId.hashCode(), builder.build())
     }
 }


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/505

This PR also fixes an issue related to "Mark as read" on some devices. There's still a minor issue on android 13 devices that is also experienced by other apps and we cannot fix it without using [hacks](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/505#issuecomment-1341081117).

### Changes:
 - Move notification-related code to a separate helper
 - Update notification instead of canceling it when sending inline replies
 - Disable notification sound on inline replies
 - Reuse existing Transaction API extensions for sending inline replies