### PR TITLE
Fixed showing all drafts (#537)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -789,11 +789,14 @@ fun Context.getAllDrafts(): HashMap<Long, String?> {
     val projection = arrayOf(Sms.BODY, Sms.THREAD_ID)
 
     try {
-        queryCursor(uri, projection) { cursor ->
-            cursor.use {
-                val threadId = cursor.getLongValue(Sms.THREAD_ID)
-                val draft = cursor.getStringValue(Sms.BODY) ?: return@queryCursor
-                drafts[threadId] = draft
+        val cursor = contentResolver.query(uri, projection, null, null, null)
+        cursor?.use {
+            while (it.moveToNext()) {
+                val threadId = it.getLongValue(Sms.THREAD_ID)
+                val draft = it.getStringValue(Sms.BODY)
+                if (draft != null) {
+                    drafts[threadId] = draft
+                }
             }
         }
     } catch (e: Exception) {


### PR DESCRIPTION
Fixes #537

Seems that function for running DB queries from Commons wasn't properly working in this case. I've written it from the basis here (fetching draft for one conversation was already done without it) and it looks to work fine. I haven't changed it in Commons because I don't know all usages of the function and could break something after changing the loop's body.

**Before:**
<img src="https://user-images.githubusercontent.com/85929121/210062771-e5628340-a664-45d2-bd71-e179dd9b1773.png" width="300">

**After:**
<img src="https://user-images.githubusercontent.com/85929121/210062869-c7d69f72-160d-4230-a96f-24776c9d0b52.png" width="300">