### PR TITLE
Avoid resetting conversation name when new messages are received

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ConversationDetailsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ConversationDetailsActivity.kt
@@ -34,7 +34,12 @@ class ConversationDetailsActivity : SimpleActivity() {
         threadId = intent.getLongExtra(THREAD_ID, 0L)
         ensureBackgroundThread {
             conversation = conversationsDB.getConversationWithThreadId(threadId)
-            participants = getThreadParticipants(threadId, null)
+            participants = if (conversation != null && conversation!!.isScheduled) {
+                val message = messagesDB.getThreadMessages(conversation!!.threadId).firstOrNull()
+                message?.participants ?: arrayListOf()
+            } else {
+                getThreadParticipants(threadId, null)
+            }
             runOnUiThread {
                 setupTextViews()
                 setupParticipants()

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
@@ -298,6 +298,7 @@ class MainActivity : SimpleActivity() {
                         .forEach { message ->
                             messagesDB.insertOrUpdate(message.copy(threadId = newConversation.threadId))
                         }
+                    insertOrUpdateConversation(newConversation, cachedConversation)
                 }
             }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
@@ -307,10 +307,8 @@ class MainActivity : SimpleActivity() {
                 }
                 if (conv != null) {
                     val lastModified = maxOf(cachedConv.date, conv.date)
-                    val usesCustomTitle = cachedConv.usesCustomTitle
-                    val title = if (usesCustomTitle) cachedConv.title else conv.title
-                    val conversation = conv.copy(date = lastModified, title = title, usesCustomTitle = usesCustomTitle)
-                    conversationsDB.insertOrUpdate(conversation)
+                    val conversation = conv.copy(date = lastModified)
+                    insertOrUpdateConversation(conversation)
                 }
             }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -494,7 +494,7 @@ class ThreadActivity : SimpleActivity() {
         if (messages.isNotEmpty() && messages.all { it.isScheduled }) {
             val scheduledMessage = messages.last()
             val fakeThreadId = generateRandomId()
-            createTemporaryThread(scheduledMessage, fakeThreadId)
+            createTemporaryThread(scheduledMessage, fakeThreadId, conversation)
             updateScheduledMessagesThreadId(messages, fakeThreadId)
             threadId = fakeThreadId
         }
@@ -1198,7 +1198,7 @@ class ThreadActivity : SimpleActivity() {
                 if (messages.isEmpty()) {
                     // create a temporary thread until a real message is sent
                     threadId = message.threadId
-                    createTemporaryThread(message, message.threadId)
+                    createTemporaryThread(message, message.threadId, conversation)
                 }
                 val conversation = conversationsDB.getConversationWithThreadId(threadId)
                 if (conversation != null) {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -824,7 +824,7 @@ fun Context.updateLastConversationMessage(threadId: Long) {
     try {
         contentResolver.delete(uri, selection, selectionArgs)
         val newConversation = getConversations(threadId)[0]
-        conversationsDB.insertOrUpdate(newConversation)
+        insertOrUpdateConversation(newConversation)
     } catch (e: Exception) {
     }
 }
@@ -876,6 +876,18 @@ fun Context.clearAllMessagesIfNeeded() {
 
 fun Context.subscriptionManagerCompat(): SubscriptionManager {
     return getSystemService(SubscriptionManager::class.java)
+}
+
+fun Context.insertOrUpdateConversation(conversation: Conversation) {
+    val cachedConv = conversationsDB.getConversationWithThreadId(conversation.threadId)
+    val updatedConv = if (cachedConv != null) {
+        val usesCustomTitle = cachedConv.usesCustomTitle
+        val title = if (usesCustomTitle) cachedConv.title else conversation.title
+        conversation.copy(title = title, usesCustomTitle = usesCustomTitle)
+    } else {
+        conversation
+    }
+    conversationsDB.insertOrUpdate(updatedConv)
 }
 
 fun Context.renameConversation(conversation: Conversation, newTitle: String): Conversation {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MmsReceiver.kt
@@ -41,7 +41,7 @@ class MmsReceiver : com.klinker.android.send_message.MmsReceivedReceiver() {
                 context.showReceivedMessageNotification(address, mms.body, mms.threadId, glideBitmap)
                 val conversation = context.getConversations(mms.threadId).firstOrNull() ?: return@post
                 ensureBackgroundThread {
-                    context.conversationsDB.insertOrUpdate(conversation)
+                    context.insertOrUpdateConversation(conversation)
                     context.updateUnreadCountBadge(context.conversationsDB.getUnreadConversations())
                     refreshMessages()
                 }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsReceiver.kt
@@ -67,7 +67,7 @@ class SmsReceiver : BroadcastReceiver() {
 
                     val conversation = context.getConversations(threadId).firstOrNull() ?: return@ensureBackgroundThread
                     try {
-                        context.conversationsDB.insertOrUpdate(conversation)
+                        context.insertOrUpdateConversation(conversation)
                     } catch (ignored: Exception) {
                     }
 


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/574

### Changes: 

 - Added an extension `insertOrUpdateConversation()` to easily update a conversation while handling renamed conversations. It's only needed when updating the local db from telephony.
 - On the conversation details screen, fetch participants lists from `messages` database in case the conversation has no real messages. 
 - Keep renamed conversation name in scheduled conversations.