### PR TITLE
Fix issue where sms_body was not being handled as an alternative to I…

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/NewConversationActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/NewConversationActivity.kt
@@ -228,7 +228,7 @@ class NewConversationActivity : SimpleActivity() {
 
     private fun launchThreadActivity(phoneNumber: String, name: String) {
         hideKeyboard()
-        val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: ""
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: intent.getStringExtra("sms_body") ?: ""
         val numbers = phoneNumber.split(";").toSet()
         val number = if (numbers.size == 1) phoneNumber else Gson().toJson(numbers)
         Intent(this, ThreadActivity::class.java).apply {


### PR DESCRIPTION
Resolved issue #618 by updating the handling of Intent.EXTRA_TEXT in Simple SMS messenger. Modified the launchThreadActivity function in NewConversationActivity.kt to fallback to 'sms_body' as the message text when sending SMS messages.