### PR TITLE
Made ThreadActivity launch in singleTop mode and added onNewIntent.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,7 +55,8 @@
             android:configChanges="orientation"
             android:exported="false"
             android:parentActivityName=".activities.MainActivity"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            android:launchMode="singleTop" />
 
         <activity
             android:name=".activities.NewConversationActivity"

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -108,6 +108,12 @@ class ThreadActivity : SimpleActivity() {
 
     private var isAttachmentPickerVisible = false
 
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        finish()
+        startActivity(intent)  
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         isMaterialActivity = true
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
Link to bug report: https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/457

The issue was that every time the notification for a message was clicked, a new ThreadActivity was added to the stack. Not only did this require users to hit back through multiple conversations to reach the MainActivity, but after a while would cause the application to lag due to too many activities being open. I've remedied this by assigning the launch mode of singleTop to the ThreadActivity. Now if ThreadActivity is the top of the stack and a notification is tapped, the current activity will be recreated with the new conversation from the notification.