### PR TITLE
refresh sms history based on oldest sms loaded, ignoring mms

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -514,7 +514,8 @@ class ThreadActivity : SimpleActivity() {
             return
         }
 
-        val dateOfFirstItem = messages.first().date
+        val firstItem = messages.first{ !it.isMMS }
+        val dateOfFirstItem = firstItem.date
         if (oldestMessageDate == dateOfFirstItem) {
             allMessagesFetched = true
             return
@@ -524,7 +525,6 @@ class ThreadActivity : SimpleActivity() {
         loadingOlderMessages = true
 
         ensureBackgroundThread {
-            val firstItem = messages.first()
             val olderMessages = getMessages(threadId, true, oldestMessageDate)
                 .filter { message -> !messages.contains(message) }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -514,7 +514,7 @@ class ThreadActivity : SimpleActivity() {
             return
         }
 
-        val firstItem = messages.first{ !it.isMMS }
+        val firstItem = messages.first()
         val dateOfFirstItem = firstItem.date
         if (oldestMessageDate == dateOfFirstItem) {
             allMessagesFetched = true
@@ -529,7 +529,7 @@ class ThreadActivity : SimpleActivity() {
                 .filter { message -> !messages.contains(message) }
 
             messages.addAll(0, olderMessages)
-            allMessagesFetched = olderMessages.size < MESSAGES_LIMIT || olderMessages.isEmpty()
+            allMessagesFetched = olderMessages.isEmpty()
             threadItems = getThreadItems()
 
             runOnUiThread {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -135,6 +135,7 @@ fun Context.getMessages(
         .filter { it.participants.isNotEmpty() }
         .filterNot { it.isScheduled && it.millis() < System.currentTimeMillis() }
         .sortedWith(compareBy<Message> { it.date }.thenBy { it.id })
+        .takeLast(limit)
         .toMutableList() as ArrayList<Message>
 
     return messages


### PR DESCRIPTION
all mms are always loaded, the number of messages only concerns sms, so only reference sms to determine the oldest loaded message

this should load all sms messages when there are mms messages in between.

until now if a mms message was the first message only messages before it would be loaded and not the messages > `MESSAGE_LIMIT` but after the mms.

Fixes: #535