### PR TITLE
Fix import for partial exports

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesImporter.kt
@@ -1,6 +1,7 @@
 package com.simplemobiletools.smsmessenger.helpers
 
 import android.content.Context
+import android.util.JsonToken
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.simplemobiletools.commons.extensions.showErrorToast
@@ -40,43 +41,38 @@ class MessagesImporter(private val context: Context) {
                     while (jsonReader.hasNext()) {
                         jsonReader.beginObject()
                         while (jsonReader.hasNext()) {
-                            if (jsonReader.nextName().equals("sms")) {
-                                if (config.importSms) {
-                                    jsonReader.beginArray()
-                                    while (jsonReader.hasNext()) {
-                                        try {
+                            val nextToken = jsonReader.peek()
+                            if (nextToken.ordinal == JsonToken.NAME.ordinal) {
+                                val msgType = jsonReader.nextName()
+
+                                if ((!msgType.equals("sms") && !msgType.equals("mms")) ||
+                                    (msgType.equals("sms") && !config.importSms) ||
+                                    (msgType.equals("mms") && !config.importMms)) {
+                                    jsonReader.skipValue()
+                                    continue
+                                }
+
+                                jsonReader.beginArray()
+                                while (jsonReader.hasNext()) {
+                                    try {
+                                        if (msgType.equals("sms")) {
                                             val message = gson.fromJson<SmsBackup>(jsonReader, smsMessageType)
                                             messageWriter.writeSmsMessage(message)
-                                            messagesImported++
-                                        } catch (e: Exception) {
-                                            context.showErrorToast(e)
-                                            messagesFailed++
-                                        }
-                                    }
-                                    jsonReader.endArray()
-                                } else {
-                                    jsonReader.skipValue()
-                                }
-                            }
-
-                            if (jsonReader.nextName().equals("mms")) {
-                                if (config.importMms) {
-                                    jsonReader.beginArray()
-
-                                    while (jsonReader.hasNext()) {
-                                        try {
+                                        } else {
                                             val message = gson.fromJson<MmsBackup>(jsonReader, mmsMessageType)
                                             messageWriter.writeMmsMessage(message)
-                                            messagesImported++
-                                        } catch (e: Exception) {
-                                            context.showErrorToast(e)
-                                            messagesFailed++
                                         }
+
+                                        messagesImported++
+                                    } catch (e: Exception) {
+                                        context.showErrorToast(e)
+                                        messagesFailed++
+
                                     }
-                                    jsonReader.endArray()
-                                } else {
-                                    jsonReader.skipValue()
                                 }
+                                jsonReader.endArray()
+                            } else {
+                                jsonReader.skipValue()
                             }
                         }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/helpers/MessagesImporter.kt
@@ -6,8 +6,11 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.simplemobiletools.commons.extensions.showErrorToast
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
-import com.simplemobiletools.smsmessenger.extensions.*
-import com.simplemobiletools.smsmessenger.helpers.MessagesImporter.ImportResult.*
+import com.simplemobiletools.smsmessenger.extensions.config
+import com.simplemobiletools.smsmessenger.helpers.MessagesImporter.ImportResult.IMPORT_FAIL
+import com.simplemobiletools.smsmessenger.helpers.MessagesImporter.ImportResult.IMPORT_NOTHING_NEW
+import com.simplemobiletools.smsmessenger.helpers.MessagesImporter.ImportResult.IMPORT_OK
+import com.simplemobiletools.smsmessenger.helpers.MessagesImporter.ImportResult.IMPORT_PARTIAL
 import com.simplemobiletools.smsmessenger.models.MmsBackup
 import com.simplemobiletools.smsmessenger.models.SmsBackup
 import java.io.File
@@ -47,7 +50,8 @@ class MessagesImporter(private val context: Context) {
 
                                 if ((!msgType.equals("sms") && !msgType.equals("mms")) ||
                                     (msgType.equals("sms") && !config.importSms) ||
-                                    (msgType.equals("mms") && !config.importMms)) {
+                                    (msgType.equals("mms") && !config.importMms)
+                                ) {
                                     jsonReader.skipValue()
                                     continue
                                 }


### PR DESCRIPTION
The previous implementation assumed that each JSON object would have an "SMS" key and a "MMS" key, and in that order. This caused an exception when it tried to read the next NAME token because the next token is actually the closing bracket of the object. This commit fixes this issue by checking that the next token is actually a NAME. If it is, we consume the token and handle it according to its value, which may be either "sms" or "mms". If it's neither of those, we skip it.

Fixes #646