### PR TITLE
Fix UI glitch cut edge

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MmsReceiver.kt
@@ -22,10 +22,7 @@ class MmsReceiver : com.klinker.android.send_message.MmsReceivedReceiver() {
 
     override fun onMessageReceived(context: Context, messageUri: Uri) {
         val mms = context.getLatestMMS() ?: return
-        val participant = mms.participants.firstOrNull {
-            it.name == mms.senderName
-        } ?: mms.participants.firstOrNull()
-        val address = participant?.phoneNumbers?.first()?.normalizedNumber ?: ""
+        val address = mms.participants.firstOrNull()?.phoneNumbers?.first()?.normalizedNumber ?: ""
 
         val size = context.resources.getDimension(R.dimen.notification_large_icon_size).toInt()
         ensureBackgroundThread {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MmsReceiver.kt
@@ -22,7 +22,10 @@ class MmsReceiver : com.klinker.android.send_message.MmsReceivedReceiver() {
 
     override fun onMessageReceived(context: Context, messageUri: Uri) {
         val mms = context.getLatestMMS() ?: return
-        val address = mms.participants.firstOrNull()?.phoneNumbers?.first()?.normalizedNumber ?: ""
+        val participant = mms.participants.firstOrNull {
+            it.name == mms.senderName
+        } ?: mms.participants.firstOrNull()
+        val address = participant?.phoneNumbers?.first()?.normalizedNumber ?: ""
 
         val size = context.resources.getDimension(R.dimen.notification_large_icon_size).toInt()
         ensureBackgroundThread {

--- a/app/src/main/res/layout/layout_thread_send_message_holder.xml
+++ b/app/src/main/res/layout/layout_thread_send_message_holder.xml
@@ -165,7 +165,7 @@
     <com.simplemobiletools.commons.views.MyButton
         android:id="@+id/thread_send_message"
         android:layout_width="@dimen/normal_icon_size"
-        android:layout_height="@dimen/normal_icon_size"
+        android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/small_margin"
         android:alpha="0.4"
         android:background="?selectableItemBackgroundBorderless"
@@ -175,6 +175,7 @@
         android:paddingVertical="@dimen/small_margin"
         android:text="@string/sms"
         android:textSize="@dimen/smaller_text_size"
+        app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintBottom_toBottomOf="@+id/thread_type_message"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/thread_type_message" />


### PR DESCRIPTION
The frame around “Internal” at the top left corner doesnt scale well. If you increase the font size in the device settings to max, only a part of the label will be visible, with the rest being cut.

| **Before** | **After** |
| --- | --- |
| <img src="https://github.com/SimpleMobileTools/Simple-SMS-Messenger/assets/20967331/9a4c6c02-0fc5-40c0-b2d1-c53f255c2129" width="350"/> | <img src="https://github.com/SimpleMobileTools/Simple-SMS-Messenger/assets/20967331/0e99f8cd-0a62-4a9f-a43a-265fc236de6e" width="350"/> |