### PR TITLE
[ISSUE-675] update last conversation message after replying from notification.

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/DirectReplyReceiver.kt
@@ -44,6 +44,8 @@ class DirectReplyReceiver : BroadcastReceiver() {
                     if (message != null) {
                         context.messagesDB.insertOrUpdate(message)
                         messageId = message.id
+
+                        context.updateLastConversationMessage(threadId)
                     }
                 } catch (e: Exception) {
                     context.showErrorToast(e)


### PR DESCRIPTION
[ISSUE-675](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/675) The application was not updating the last conversation when you reply a message from the notification actions. We had to launch the app and refresh to see the cache refreshing. This PR updates the last message in the conversation after you reply. Now when you launch the app and you are able to see the expected state.