### PR TITLE
Add message details menu button

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:4c83ec8740'
+    implementation 'com.github.esensar:Simple-Commons:7b890eae3e'
     implementation 'org.greenrobot:eventbus:3.3.1'
     implementation 'com.github.tibbi:IndicatorFastScroll:4524cd0b61'
     implementation 'com.github.tibbi:android-smsmms:33fcaf94d9'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.esensar:Simple-Commons:7b890eae3e'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:b4cc381943'
     implementation 'org.greenrobot:eventbus:3.3.1'
     implementation 'com.github.tibbi:IndicatorFastScroll:4524cd0b61'
     implementation 'com.github.tibbi:android-smsmms:33fcaf94d9'

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -1602,7 +1602,6 @@ class ThreadActivity : SimpleActivity() {
             status = STATUS_NONE,
             participants = participants,
             date = (scheduledDateTime.millis / 1000).toInt(),
-            dateSent = (scheduledDateTime.millis / 1000).toInt(),
             read = false,
             threadId = threadId,
             isMMS = isMmsMessage(text),

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/ThreadActivity.kt
@@ -1602,6 +1602,7 @@ class ThreadActivity : SimpleActivity() {
             status = STATUS_NONE,
             participants = participants,
             date = (scheduledDateTime.millis / 1000).toInt(),
+            dateSent = (scheduledDateTime.millis / 1000).toInt(),
             read = false,
             threadId = threadId,
             isMMS = isMmsMessage(text),

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -192,7 +192,6 @@ class ThreadAdapter(
         MessageDetailsDialog(activity, message)
     }
 
-
     private fun askConfirmDelete() {
         val itemsCnt = selectedKeys.size
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/adapters/ThreadAdapter.kt
@@ -33,6 +33,7 @@ import com.simplemobiletools.smsmessenger.activities.NewConversationActivity
 import com.simplemobiletools.smsmessenger.activities.SimpleActivity
 import com.simplemobiletools.smsmessenger.activities.ThreadActivity
 import com.simplemobiletools.smsmessenger.activities.VCardViewerActivity
+import com.simplemobiletools.smsmessenger.dialogs.MessageDetailsDialog
 import com.simplemobiletools.smsmessenger.dialogs.SelectTextDialog
 import com.simplemobiletools.smsmessenger.extensions.*
 import com.simplemobiletools.smsmessenger.helpers.*
@@ -82,6 +83,7 @@ class ThreadAdapter(
             findItem(R.id.cab_share).isVisible = isOneItemSelected && hasText
             findItem(R.id.cab_forward_message).isVisible = isOneItemSelected
             findItem(R.id.cab_select_text).isVisible = isOneItemSelected && hasText
+            findItem(R.id.cab_properties).isVisible = isOneItemSelected
         }
     }
 
@@ -98,6 +100,7 @@ class ThreadAdapter(
             R.id.cab_select_text -> selectText()
             R.id.cab_delete -> askConfirmDelete()
             R.id.cab_select_all -> selectAll()
+            R.id.cab_properties -> showMessageDetails()
         }
     }
 
@@ -183,6 +186,12 @@ class ThreadAdapter(
             SelectTextDialog(activity, firstItem.body)
         }
     }
+
+    private fun showMessageDetails() {
+        val message = getSelectedItems().firstOrNull() as? Message ?: return
+        MessageDetailsDialog(activity, message)
+    }
+
 
     private fun askConfirmDelete() {
         val itemsCnt = selectedKeys.size

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/databases/MessagesDatabase.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/databases/MessagesDatabase.kt
@@ -17,7 +17,7 @@ import com.simplemobiletools.smsmessenger.models.Conversation
 import com.simplemobiletools.smsmessenger.models.Message
 import com.simplemobiletools.smsmessenger.models.MessageAttachment
 
-@Database(entities = [Conversation::class, Attachment::class, MessageAttachment::class, Message::class], version = 8)
+@Database(entities = [Conversation::class, Attachment::class, MessageAttachment::class, Message::class], version = 7)
 @TypeConverters(Converters::class)
 abstract class MessagesDatabase : RoomDatabase() {
 
@@ -44,7 +44,6 @@ abstract class MessagesDatabase : RoomDatabase() {
                             .addMigrations(MIGRATION_4_5)
                             .addMigrations(MIGRATION_5_6)
                             .addMigrations(MIGRATION_6_7)
-                            .addMigrations(MIGRATION_7_8)
                             .build()
                     }
                 }
@@ -113,15 +112,6 @@ abstract class MessagesDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.apply {
                     execSQL("ALTER TABLE messages ADD COLUMN sender_phone_number TEXT NOT NULL DEFAULT ''")
-                }
-            }
-        }
-
-        private val MIGRATION_7_8 = object : Migration(7, 8) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.apply {
-                    execSQL("ALTER TABLE messages ADD COLUMN date_sent INTEGER NOT NULL DEFAULT 0")
-                    execSQL("UPDATE messages SET date_sent = date")
                 }
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/databases/MessagesDatabase.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/databases/MessagesDatabase.kt
@@ -17,7 +17,7 @@ import com.simplemobiletools.smsmessenger.models.Conversation
 import com.simplemobiletools.smsmessenger.models.Message
 import com.simplemobiletools.smsmessenger.models.MessageAttachment
 
-@Database(entities = [Conversation::class, Attachment::class, MessageAttachment::class, Message::class], version = 7)
+@Database(entities = [Conversation::class, Attachment::class, MessageAttachment::class, Message::class], version = 8)
 @TypeConverters(Converters::class)
 abstract class MessagesDatabase : RoomDatabase() {
 
@@ -44,6 +44,7 @@ abstract class MessagesDatabase : RoomDatabase() {
                             .addMigrations(MIGRATION_4_5)
                             .addMigrations(MIGRATION_5_6)
                             .addMigrations(MIGRATION_6_7)
+                            .addMigrations(MIGRATION_7_8)
                             .build()
                     }
                 }
@@ -112,6 +113,15 @@ abstract class MessagesDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.apply {
                     execSQL("ALTER TABLE messages ADD COLUMN sender_phone_number TEXT NOT NULL DEFAULT ''")
+                }
+            }
+        }
+
+        private val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.apply {
+                    execSQL("ALTER TABLE messages ADD COLUMN date_sent INTEGER NOT NULL DEFAULT 0")
+                    execSQL("UPDATE messages SET date_sent = date")
                 }
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
@@ -3,48 +3,41 @@ package com.simplemobiletools.smsmessenger.dialogs
 import android.annotation.SuppressLint
 import android.telephony.SubscriptionInfo
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
-import com.simplemobiletools.commons.extensions.getAlertDialogBuilder
-import com.simplemobiletools.commons.extensions.getTimeFormat
-import com.simplemobiletools.commons.extensions.setupDialogStuff
+import com.simplemobiletools.commons.dialogs.BasePropertiesDialog
+import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.extensions.config
 import com.simplemobiletools.smsmessenger.extensions.subscriptionManagerCompat
 import com.simplemobiletools.smsmessenger.models.Message
-import kotlinx.android.synthetic.main.dialog_message_details.view.dialog_message_details_text_value
 import org.joda.time.DateTime
 
-class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Message) {
+class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Message) : BasePropertiesDialog(activity) {
     init {
         @SuppressLint("MissingPermission")
         val availableSIMs = activity.subscriptionManagerCompat().activeSubscriptionInfoList
 
-        @SuppressLint("SetTextI18n")
-        val view = activity.layoutInflater.inflate(R.layout.dialog_message_details, null).apply {
-            dialog_message_details_text_value.text = mutableListOf<String>().apply {
-                add("${message.getReceiverOrSenderLabel()}: ${message.getReceiverOrSenderPhoneNumbers()}")
-                if (availableSIMs.count() > 1) {
-                    add("SIM: ${message.getSIM(availableSIMs)}")
-                }
-                add("${message.getSentOrReceivedAtLabel()}: ${message.getSentOrReceivedAt()}")
-            }.joinToString(separator = System.lineSeparator())
+        addProperty(message.getSenderOrReceiverLabel(), message.getSenderOrReceiverPhoneNumbers())
+        if (availableSIMs.count() > 1) {
+            addProperty(R.string.message_details_sim, message.getSIM(availableSIMs))
         }
+        addProperty(message.getSentOrReceivedAtLabel(), message.getSentOrReceivedAt())
 
         activity.getAlertDialogBuilder()
             .setPositiveButton(R.string.ok) { _, _ -> }
             .apply {
-                activity.setupDialogStuff(view, this, R.string.message_details)
+                activity.setupDialogStuff(mDialogView, this, R.string.message_details)
             }
     }
 
-    private fun Message.getReceiverOrSenderLabel(): String {
+    private fun Message.getSenderOrReceiverLabel(): Int {
         return if (isReceivedMessage()) {
-            activity.getString(R.string.message_details_sender)
+            R.string.message_details_sender
         } else {
-            activity.getString(R.string.message_details_receiver)
+            R.string.message_details_receiver
         }
     }
 
-    private fun Message.getReceiverOrSenderPhoneNumbers(): String {
+    private fun Message.getSenderOrReceiverPhoneNumbers(): String {
         return if (isReceivedMessage()) {
             formatContactInfo(senderName, senderPhoneNumber)
         } else {
@@ -66,11 +59,11 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
         return availableSIMs.firstOrNull { it.subscriptionId == subscriptionId }?.displayName?.toString() ?: activity.getString(R.string.unknown)
     }
 
-    private fun Message.getSentOrReceivedAtLabel(): String {
+    private fun Message.getSentOrReceivedAtLabel(): Int {
         return if (isReceivedMessage()) {
-            activity.getString(R.string.message_details_received_at)
+            R.string.message_details_received_at
         } else {
-            activity.getString(R.string.message_details_sent_at)
+            R.string.message_details_sent_at
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
@@ -21,15 +21,11 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
         @SuppressLint("SetTextI18n")
         val view = activity.layoutInflater.inflate(R.layout.dialog_message_details, null).apply {
             dialog_message_details_text_value.text = mutableListOf<String>().apply {
-                add("${activity.getString(R.string.message_details_type)}: ${message.getMessageType()}")
                 add("${message.getReceiverOrSenderLabel()}: ${message.getReceiverOrSenderPhoneNumbers()}")
                 if (availableSIMs.count() > 1) {
                     add("SIM: ${message.getSIM(availableSIMs)}")
                 }
-                add("${activity.getString(R.string.message_details_sent_at)}: ${message.getSentAt()}")
-                if (message.isReceivedMessage()) {
-                    add("${activity.getString(R.string.message_details_received_at)}: ${message.getReceivedAt()}")
-                }
+                add("${message.getSentOrReceivedAtLabel()}: ${message.getSentOrReceivedAt()}")
             }.joinToString(separator = System.lineSeparator())
         }
 
@@ -39,8 +35,6 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
                 activity.setupDialogStuff(view, this, R.string.message_details)
             }
     }
-
-    private fun Message.getMessageType(): String = if (isMMS) "MMS" else "SMS"
 
     private fun Message.getReceiverOrSenderLabel(): String {
         return if (isReceivedMessage()) {
@@ -60,11 +54,15 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
         return availableSIMs.firstOrNull { it.subscriptionId == subscriptionId }?.displayName?.toString() ?: activity.getString(R.string.unknown)
     }
 
-    private fun Message.getSentAt(): String {
-        return DateTime(dateSent * 1000L).toString(activity.config.dateFormat + " " + activity.getTimeFormat())
+    private fun Message.getSentOrReceivedAtLabel(): String {
+        return if (isReceivedMessage()) {
+            activity.getString(R.string.message_details_received_at)
+        } else {
+            activity.getString(R.string.message_details_sent_at)
+        }
     }
 
-    private fun Message.getReceivedAt(): String {
+    private fun Message.getSentOrReceivedAt(): String {
         return DateTime(date * 1000L).toString("${activity.config.dateFormat} ${activity.getTimeFormat()}")
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
@@ -45,8 +45,20 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
     }
 
     private fun Message.getReceiverOrSenderPhoneNumbers(): String {
-        return participants.joinToString(", ") {
-            it.phoneNumbers.first().value
+        return if (isReceivedMessage()) {
+            formatContactInfo(senderName, senderPhoneNumber)
+        } else {
+            participants.joinToString(", ") {
+                formatContactInfo(it.name, it.phoneNumbers.first().value)
+            }
+        }
+    }
+
+    private fun formatContactInfo(name: String, phoneNumber: String): String {
+        return if (name != phoneNumber) {
+            "$name ($phoneNumber)"
+        } else {
+            phoneNumber
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
@@ -20,13 +20,17 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
 
         @SuppressLint("SetTextI18n")
         val view = activity.layoutInflater.inflate(R.layout.dialog_message_details, null).apply {
-            dialog_message_details_text_value.text = """
-                 ${activity.getString(R.string.message_details_type)}: ${message.getMessageType()}
-                 ${message.getReceiverOrSenderLabel()}: ${message.getReceiverOrSenderPhoneNumbers()}
-                 SIM: ${message.getSIM(availableSIMs)}
-                 ${activity.getString(R.string.message_details_sent_at)}: ${message.getSentAt()}
-                 ${message.getReceivedAtLine()}
-            """.trimIndent().trimEnd()
+            dialog_message_details_text_value.text = mutableListOf<String>().apply {
+                add("${activity.getString(R.string.message_details_type)}: ${message.getMessageType()}")
+                add("${message.getReceiverOrSenderLabel()}: ${message.getReceiverOrSenderPhoneNumbers()}")
+                if (availableSIMs.count() > 1) {
+                    add("SIM: ${message.getSIM(availableSIMs)}")
+                }
+                add("${activity.getString(R.string.message_details_sent_at)}: ${message.getSentAt()}")
+                if (message.isReceivedMessage()) {
+                    add("${activity.getString(R.string.message_details_received_at)}: ${message.getReceivedAt()}")
+                }
+            }.joinToString(separator = System.lineSeparator())
         }
 
         activity.getAlertDialogBuilder()
@@ -58,14 +62,6 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
 
     private fun Message.getSentAt(): String {
         return DateTime(dateSent * 1000L).toString(activity.config.dateFormat + " " + activity.getTimeFormat())
-    }
-
-    private fun Message.getReceivedAtLine(): String {
-        return if (isReceivedMessage()) {
-            "${activity.getString(R.string.message_details_received_at)}: ${getReceivedAt()}"
-        } else {
-            ""
-        }
     }
 
     private fun Message.getReceivedAt(): String {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
@@ -1,0 +1,72 @@
+package com.simplemobiletools.smsmessenger.dialogs
+
+import android.annotation.SuppressLint
+import android.telephony.SubscriptionInfo
+import com.simplemobiletools.commons.activities.BaseSimpleActivity
+import com.simplemobiletools.commons.extensions.getAlertDialogBuilder
+import com.simplemobiletools.commons.extensions.getTimeFormat
+import com.simplemobiletools.commons.extensions.setupDialogStuff
+import com.simplemobiletools.smsmessenger.R
+import com.simplemobiletools.smsmessenger.extensions.config
+import com.simplemobiletools.smsmessenger.extensions.subscriptionManagerCompat
+import com.simplemobiletools.smsmessenger.models.Message
+import kotlinx.android.synthetic.main.dialog_message_details.view.dialog_message_details_text_value
+import org.joda.time.DateTime
+
+class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Message) {
+    init {
+        @SuppressLint("MissingPermission")
+        val availableSIMs = activity.subscriptionManagerCompat().activeSubscriptionInfoList
+
+        @SuppressLint("SetTextI18n")
+        val view = activity.layoutInflater.inflate(R.layout.dialog_message_details, null).apply {
+            dialog_message_details_text_value.text = """
+                 ${activity.getString(R.string.message_details_type)}: ${message.getMessageType()}
+                 ${message.getReceiverOrSenderLabel()}: ${message.getReceiverOrSenderPhoneNumbers()}
+                 SIM: ${message.getSIM(availableSIMs)}
+                 ${activity.getString(R.string.message_details_sent_at)}: ${message.getSentAt()}
+                 ${message.getReceivedAtLine()}
+            """.trimIndent().trimEnd()
+        }
+
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(R.string.ok) { _, _ -> }
+            .apply {
+                activity.setupDialogStuff(view, this, R.string.message_details)
+            }
+    }
+
+    private fun Message.getMessageType(): String = if (isMMS) "MMS" else "SMS"
+
+    private fun Message.getReceiverOrSenderLabel(): String {
+        return if (isReceivedMessage()) {
+            activity.getString(R.string.message_details_sender)
+        } else {
+            activity.getString(R.string.message_details_receiver)
+        }
+    }
+
+    private fun Message.getReceiverOrSenderPhoneNumbers(): String {
+        return participants.joinToString(", ") { it.phoneNumbers.first().value }
+    }
+
+    private fun Message.getSIM(availableSIMs: List<SubscriptionInfo>): String {
+        return availableSIMs.firstOrNull { it.subscriptionId == subscriptionId }?.displayName?.toString() ?: activity.getString(R.string.unknown)
+    }
+
+    private fun Message.getSentAt(): String {
+        return DateTime(dateSent * 1000L).toString(activity.config.dateFormat + " " + activity.getTimeFormat())
+    }
+
+    private fun Message.getReceivedAtLine(): String {
+        return if (isReceivedMessage()) {
+            "${activity.getString(R.string.message_details_received_at)}: ${getReceivedAt()}"
+        } else {
+            ""
+        }
+    }
+
+    private fun Message.getReceivedAt(): String {
+        return DateTime(date * 1000L).toString(activity.config.dateFormat + " " + activity.getTimeFormat())
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
@@ -47,7 +47,9 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
     }
 
     private fun Message.getReceiverOrSenderPhoneNumbers(): String {
-        return participants.joinToString(", ") { it.phoneNumbers.first().value }
+        return participants.joinToString(", ") {
+            it.phoneNumbers.first().value
+        }
     }
 
     private fun Message.getSIM(availableSIMs: List<SubscriptionInfo>): String {

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/dialogs/MessageDetailsDialog.kt
@@ -67,6 +67,6 @@ class MessageDetailsDialog(val activity: BaseSimpleActivity, val message: Messag
     }
 
     private fun Message.getReceivedAt(): String {
-        return DateTime(date * 1000L).toString(activity.config.dateFormat + " " + activity.getTimeFormat())
+        return DateTime(date * 1000L).toString("${activity.config.dateFormat} ${activity.getTimeFormat()}")
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -70,6 +70,7 @@ fun Context.getMessages(
         Sms.TYPE,
         Sms.ADDRESS,
         Sms.DATE,
+        Sms.DATE_SENT,
         Sms.READ,
         Sms.THREAD_ID,
         Sms.SUBSCRIPTION_ID,
@@ -106,6 +107,7 @@ fun Context.getMessages(
         val senderName = namePhoto.name
         val photoUri = namePhoto.photoUri ?: ""
         val date = (cursor.getLongValue(Sms.DATE) / 1000).toInt()
+        val dateSent = (cursor.getLongValue(Sms.DATE_SENT) / 1000).toInt()
         val read = cursor.getIntValue(Sms.READ) == 1
         val thread = cursor.getLongValue(Sms.THREAD_ID)
         val subscriptionId = cursor.getIntValue(Sms.SUBSCRIPTION_ID)
@@ -117,7 +119,23 @@ fun Context.getMessages(
         }
         val isMMS = false
         val message =
-            Message(id, body, type, status, ArrayList(participants), date, read, thread, isMMS, null, senderNumber, senderName, photoUri, subscriptionId)
+            Message(
+                id,
+                body,
+                type,
+                status,
+                ArrayList(participants),
+                date,
+                dateSent,
+                read,
+                thread,
+                isMMS,
+                null,
+                senderNumber,
+                senderName,
+                photoUri,
+                subscriptionId
+            )
         messages.add(message)
     }
 
@@ -148,6 +166,7 @@ fun Context.getMMS(threadId: Long? = null, getImageResolutions: Boolean = false,
     val projection = arrayOf(
         Mms._ID,
         Mms.DATE,
+        Mms.DATE_SENT,
         Mms.READ,
         Mms.MESSAGE_BOX,
         Mms.THREAD_ID,
@@ -175,6 +194,7 @@ fun Context.getMMS(threadId: Long? = null, getImageResolutions: Boolean = false,
         val mmsId = cursor.getLongValue(Mms._ID)
         val type = cursor.getIntValue(Mms.MESSAGE_BOX)
         val date = cursor.getLongValue(Mms.DATE).toInt()
+        val dateSent = cursor.getLongValue(Mms.DATE_SENT).toInt()
         val read = cursor.getIntValue(Mms.READ) == 1
         val threadId = cursor.getLongValue(Mms.THREAD_ID)
         val subscriptionId = cursor.getIntValue(Mms.SUBSCRIPTION_ID)
@@ -202,7 +222,23 @@ fun Context.getMMS(threadId: Long? = null, getImageResolutions: Boolean = false,
         }
 
         val message =
-            Message(mmsId, body, type, status, participants, date, read, threadId, isMMS, attachment, senderNumber, senderName, senderPhotoUri, subscriptionId)
+            Message(
+                mmsId,
+                body,
+                type,
+                status,
+                participants,
+                date,
+                dateSent,
+                read,
+                threadId,
+                isMMS,
+                attachment,
+                senderNumber,
+                senderName,
+                senderPhotoUri,
+                subscriptionId
+            )
         messages.add(message)
 
         participants.forEach {
@@ -560,13 +596,24 @@ fun Context.getNameAndPhotoFromPhoneNumber(number: String): NamePhoto {
     return NamePhoto(number, null)
 }
 
-fun Context.insertNewSMS(address: String, subject: String, body: String, date: Long, read: Int, threadId: Long, type: Int, subscriptionId: Int): Long {
+fun Context.insertNewSMS(
+    address: String,
+    subject: String,
+    body: String,
+    date: Long,
+    dateSent: Long,
+    read: Int,
+    threadId: Long,
+    type: Int,
+    subscriptionId: Int
+): Long {
     val uri = Sms.CONTENT_URI
     val contentValues = ContentValues().apply {
         put(Sms.ADDRESS, address)
         put(Sms.SUBJECT, subject)
         put(Sms.BODY, body)
         put(Sms.DATE, date)
+        put(Sms.DATE_SENT, dateSent)
         put(Sms.READ, read)
         put(Sms.THREAD_ID, threadId)
         put(Sms.TYPE, type)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/extensions/Context.kt
@@ -70,7 +70,6 @@ fun Context.getMessages(
         Sms.TYPE,
         Sms.ADDRESS,
         Sms.DATE,
-        Sms.DATE_SENT,
         Sms.READ,
         Sms.THREAD_ID,
         Sms.SUBSCRIPTION_ID,
@@ -107,7 +106,6 @@ fun Context.getMessages(
         val senderName = namePhoto.name
         val photoUri = namePhoto.photoUri ?: ""
         val date = (cursor.getLongValue(Sms.DATE) / 1000).toInt()
-        val dateSent = (cursor.getLongValue(Sms.DATE_SENT) / 1000).toInt()
         val read = cursor.getIntValue(Sms.READ) == 1
         val thread = cursor.getLongValue(Sms.THREAD_ID)
         val subscriptionId = cursor.getIntValue(Sms.SUBSCRIPTION_ID)
@@ -126,7 +124,6 @@ fun Context.getMessages(
                 status,
                 ArrayList(participants),
                 date,
-                dateSent,
                 read,
                 thread,
                 isMMS,
@@ -166,7 +163,6 @@ fun Context.getMMS(threadId: Long? = null, getImageResolutions: Boolean = false,
     val projection = arrayOf(
         Mms._ID,
         Mms.DATE,
-        Mms.DATE_SENT,
         Mms.READ,
         Mms.MESSAGE_BOX,
         Mms.THREAD_ID,
@@ -194,7 +190,6 @@ fun Context.getMMS(threadId: Long? = null, getImageResolutions: Boolean = false,
         val mmsId = cursor.getLongValue(Mms._ID)
         val type = cursor.getIntValue(Mms.MESSAGE_BOX)
         val date = cursor.getLongValue(Mms.DATE).toInt()
-        val dateSent = cursor.getLongValue(Mms.DATE_SENT).toInt()
         val read = cursor.getIntValue(Mms.READ) == 1
         val threadId = cursor.getLongValue(Mms.THREAD_ID)
         val subscriptionId = cursor.getIntValue(Mms.SUBSCRIPTION_ID)
@@ -229,7 +224,6 @@ fun Context.getMMS(threadId: Long? = null, getImageResolutions: Boolean = false,
                 status,
                 participants,
                 date,
-                dateSent,
                 read,
                 threadId,
                 isMMS,
@@ -601,7 +595,6 @@ fun Context.insertNewSMS(
     subject: String,
     body: String,
     date: Long,
-    dateSent: Long,
     read: Int,
     threadId: Long,
     type: Int,
@@ -613,7 +606,6 @@ fun Context.insertNewSMS(
         put(Sms.SUBJECT, subject)
         put(Sms.BODY, body)
         put(Sms.DATE, date)
-        put(Sms.DATE_SENT, dateSent)
         put(Sms.READ, read)
         put(Sms.THREAD_ID, threadId)
         put(Sms.TYPE, type)

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/models/Message.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/models/Message.kt
@@ -14,6 +14,7 @@ data class Message(
     @ColumnInfo(name = "status") val status: Int,
     @ColumnInfo(name = "participants") val participants: ArrayList<SimpleContact>,
     @ColumnInfo(name = "date") val date: Int,
+    @ColumnInfo(name = "date_sent") val dateSent: Int,
     @ColumnInfo(name = "read") val read: Boolean,
     @ColumnInfo(name = "thread_id") val threadId: Long,
     @ColumnInfo(name = "is_mms") val isMMS: Boolean,
@@ -58,6 +59,7 @@ data class Message(
             return old.body == new.body &&
                 old.threadId == new.threadId &&
                 old.date == new.date &&
+                old.dateSent == new.dateSent &&
                 old.isMMS == new.isMMS &&
                 old.attachment == new.attachment &&
                 old.senderPhoneNumber == new.senderPhoneNumber &&

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/models/Message.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/models/Message.kt
@@ -14,7 +14,6 @@ data class Message(
     @ColumnInfo(name = "status") val status: Int,
     @ColumnInfo(name = "participants") val participants: ArrayList<SimpleContact>,
     @ColumnInfo(name = "date") val date: Int,
-    @ColumnInfo(name = "date_sent") val dateSent: Int,
     @ColumnInfo(name = "read") val read: Boolean,
     @ColumnInfo(name = "thread_id") val threadId: Long,
     @ColumnInfo(name = "is_mms") val isMMS: Boolean,
@@ -59,7 +58,6 @@ data class Message(
             return old.body == new.body &&
                 old.threadId == new.threadId &&
                 old.date == new.date &&
-                old.dateSent == new.dateSent &&
                 old.isMMS == new.isMMS &&
                 old.attachment == new.attachment &&
                 old.senderPhoneNumber == new.senderPhoneNumber &&

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/SmsReceiver.kt
@@ -24,6 +24,7 @@ class SmsReceiver : BroadcastReceiver() {
         var body = ""
         var subject = ""
         var date = 0L
+        var dateSent = 0L
         var threadId = 0L
         var status = Telephony.Sms.STATUS_NONE
         val type = Telephony.Sms.MESSAGE_TYPE_INBOX
@@ -38,6 +39,7 @@ class SmsReceiver : BroadcastReceiver() {
                 status = it.status
                 body += it.messageBody
                 date = System.currentTimeMillis()
+                dateSent = it.timestampMillis
                 threadId = context.getThreadId(address)
             }
 
@@ -45,17 +47,27 @@ class SmsReceiver : BroadcastReceiver() {
                 val simpleContactsHelper = SimpleContactsHelper(context)
                 simpleContactsHelper.exists(address, privateCursor) { exists ->
                     if (exists) {
-                        handleMessage(context, address, subject, body, date, read, threadId, type, subscriptionId, status)
+                        handleMessage(context, address, subject, body, date, dateSent, read, threadId, type, subscriptionId, status)
                     }
                 }
             } else {
-                handleMessage(context, address, subject, body, date, read, threadId, type, subscriptionId, status)
+                handleMessage(context, address, subject, body, date, dateSent, read, threadId, type, subscriptionId, status)
             }
         }
     }
 
     private fun handleMessage(
-        context: Context, address: String, subject: String, body: String, date: Long, read: Int, threadId: Long, type: Int, subscriptionId: Int, status: Int
+        context: Context,
+        address: String,
+        subject: String,
+        body: String,
+        date: Long,
+        dateSent: Long,
+        read: Int,
+        threadId: Long,
+        type: Int,
+        subscriptionId: Int,
+        status: Int
     ) {
         val photoUri = SimpleContactsHelper(context).getPhotoUriFromPhoneNumber(address)
         val bitmap = context.getNotificationBitmap(photoUri)
@@ -63,7 +75,7 @@ class SmsReceiver : BroadcastReceiver() {
             if (!context.isNumberBlocked(address)) {
                 val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
                 ensureBackgroundThread {
-                    val newMessageId = context.insertNewSMS(address, subject, body, date, read, threadId, type, subscriptionId)
+                    val newMessageId = context.insertNewSMS(address, subject, body, date, dateSent, read, threadId, type, subscriptionId)
 
                     val conversation = context.getConversations(threadId).firstOrNull() ?: return@ensureBackgroundThread
                     try {
@@ -81,6 +93,7 @@ class SmsReceiver : BroadcastReceiver() {
                     val participant = SimpleContact(0, 0, senderName, photoUri, arrayListOf(phoneNumber), ArrayList(), ArrayList())
                     val participants = arrayListOf(participant)
                     val messageDate = (date / 1000).toInt()
+                    val messageSentDate = (dateSent / 1000).toInt()
 
                     val message =
                         Message(
@@ -90,6 +103,7 @@ class SmsReceiver : BroadcastReceiver() {
                             status,
                             participants,
                             messageDate,
+                            messageSentDate,
                             false,
                             threadId,
                             false,

--- a/app/src/main/res/layout/dialog_message_details.xml
+++ b/app/src/main/res/layout/dialog_message_details.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.simplemobiletools.commons.views.MyTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/dialog_message_details_text_value"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/big_margin"
+    android:paddingTop="@dimen/big_margin"
+    android:paddingEnd="@dimen/big_margin"
+    android:textIsSelectable="true"
+    android:textSize="@dimen/big_text_size"
+    tools:text="My sample text" />

--- a/app/src/main/res/menu/cab_thread.xml
+++ b/app/src/main/res/menu/cab_thread.xml
@@ -27,6 +27,11 @@
         android:title="@string/save_as"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/cab_properties"
+        android:icon="@drawable/ic_info_vector"
+        android:title="@string/properties"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/cab_forward_message"
         android:showAsAction="never"
         android:title="@string/forward_message"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -54,8 +54,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">تم تلقي الرسائل القصيرة</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -54,7 +54,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -54,7 +54,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">تم تلقي الرسائل القصيرة</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -54,6 +54,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -50,6 +50,13 @@
     <string name="schedule_send_warning">استمر في تشغيل الهاتف وتأكد من عدم وجود شيء يقتل التطبيق أثناء وجوده في الخلفية.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">ارسل الان</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">تم تلقي الرسائل القصيرة</string>
     <string name="new_message">رسالة جديدة</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">New message</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -52,6 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -52,8 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Атрымана паведамленне</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -52,7 +52,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -48,6 +48,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Атрымана паведамленне</string>
     <string name="new_message">Новае паведамленне</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -52,7 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Атрымана паведамленне</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Получено съобщение</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Получено съобщение</string>
     <string name="new_message">Ново съобщение</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Получено съобщение</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS rebut</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS rebut</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Mantingueu el telèfon engegat i assegureu-vos que no hi hagi res que mati les aplicacions en segon pla.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Envia ara</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS rebut</string>
     <string name="new_message">Missatge nou</string>

--- a/app/src/main/res/values-cr/strings.xml
+++ b/app/src/main/res/values-cr/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-cr/strings.xml
+++ b/app/src/main/res/values-cr/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-cr/strings.xml
+++ b/app/src/main/res/values-cr/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-cr/strings.xml
+++ b/app/src/main/res/values-cr/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">New message</string>

--- a/app/src/main/res/values-cr/strings.xml
+++ b/app/src/main/res/values-cr/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Ponechte telefon zapnutý a ujistěte se, že nic nezabije aplikaci běžící na pozadí.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Odeslat nyní</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Přijaté SMS</string>
     <string name="new_message">Nová zpráva</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Přijaté SMS</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Přijaté SMS</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Modtag SMS</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Modtag SMS</string>
     <string name="new_message">Ny Besked</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Modtag SMS</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Empfangene SMS</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Lassen Sie das Telefon eingeschaltet und vergewissern Sie sich, dass die Anwendung im Hintergrund nicht abgeschaltet wird.</string>
     <string name="update_message">Nachricht aktualisieren</string>
     <string name="send_now">Jetzt senden</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Empfangene SMS</string>
     <string name="new_message">Neue Nachricht</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Empfangene SMS</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Κρατήστε το τηλέφωνο ανοιχτό και βεβαιωθείτε ότι δεν υπάρχει τίποτα που να κλείνει την εφαρμογή ενώ βρίσκεται στο παρασκήνιο.</string>
     <string name="update_message">Ενημέρωση μηνύματος</string>
     <string name="send_now">Αποστολή τώρα</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Ελήφθη SMS</string>
     <string name="new_message">Νέο μήνυμα</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Ελήφθη SMS</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Ελήφθη SMS</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">Nova mesaĝo</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Mensaje recibido</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Mantenga el teléfono encendido y asegúrese de que no hay nada que mate la aplicación en segundo plano.</string>
     <string name="update_message">Actualizar mensaje</string>
     <string name="send_now">Enviar ahora</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Mensaje recibido</string>
     <string name="new_message">Nuevo mensaje</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Mensaje recibido</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Vaata, et telefon oleks sisse lülitatud ja mitte miski ei katkestaks selle rakenduse tööd taustal.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Saada kohe</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Vastuvõetud SMS</string>
     <string name="new_message">Uus sõnum</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Vastuvõetud SMS</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Vastuvõetud SMS</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Vastaanotettu tekstiviesti</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Vastaanotettu tekstiviesti</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Pidä puhelin päällä ja varmista, ettei sovellusta lopeteta taustalla.</string>
     <string name="update_message">Päivitä viesti</string>
     <string name="send_now">Lähetä nyt</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Vastaanotettu tekstiviesti</string>
     <string name="new_message">Uusi viesti</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS reçu</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Gardez le téléphone allumé et assurez-vous que l\'application ne soit pas fermée en arrière-plan.</string>
     <string name="update_message">Mettre à jour le message</string>
     <string name="send_now">Envoyer maintenant</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS reçu</string>
     <string name="new_message">Nouveau message</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS reçu</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Mantén o teléfono acendido e asegúrate de que non hai nada que mate a aplicación en segundo plano.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Enviar agora</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recibida</string>
     <string name="new_message">Nova mensaxe</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recibida</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recibida</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">New message</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Pojedinosti poruke</string>
     <string name="message_details_sender">Šalje</string>
     <string name="message_details_receiver">Prima</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Poslano</string>
     <string name="message_details_received_at">Primljeno</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Pojedinosti poruke</string>
     <string name="message_details_sender">Šalje</string>
     <string name="message_details_receiver">Prima</string>
-    <string name="message_details_type">Vrsta</string>
     <string name="message_details_sent_at">Poslano</string>
     <string name="message_details_received_at">Primljeno</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Pojedinosti poruke</string>
     <string name="message_details_sender">Šalje</string>
     <string name="message_details_receiver">Prima</string>
-        <string name="message_details_sent_at">Poslano</string>
+    <string name="message_details_sent_at">Poslano</string>
     <string name="message_details_received_at">Primljeno</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Primljene SMS poruke</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Ostavi telefon uključen i provjeri da ništa ne prekida rad aplikacije kada je u pozadini.</string>
     <string name="update_message">Ažuriraj poruku</string>
     <string name="send_now">Pošalji sada</string>
+    <!-- Message details -->
+    <string name="message_details">Pojedinosti poruke</string>
+    <string name="message_details_sender">Šalje</string>
+    <string name="message_details_receiver">Prima</string>
+    <string name="message_details_type">Vrsta</string>
+    <string name="message_details_sent_at">Poslano</string>
+    <string name="message_details_received_at">Primljeno</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Primljene SMS poruke</string>
     <string name="new_message">Nova poruka</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Pojedinosti poruke</string>
     <string name="message_details_sender">Šalje</string>
     <string name="message_details_receiver">Prima</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Poslano</string>
+        <string name="message_details_sent_at">Poslano</string>
     <string name="message_details_received_at">Primljeno</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Primljene SMS poruke</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS fogadva</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS fogadva</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Tartsa bekapcsolva a telefont, és győződjön meg róla, hogy semmi sem lövi ki az alkalmazást a háttérben.</string>
     <string name="update_message">Üzenet frissítése</string>
     <string name="send_now">Küldés most</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS fogadva</string>
     <string name="new_message">Új üzenet</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -45,6 +45,13 @@
     <string name="schedule_send_warning">Tetap nyalakan ponsel dan pastikan tidak ada apa pun yang menutup aplikasi selagi di latar belakang.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Kirim sekarang</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Menerima SMS</string>
     <string name="new_message">Pesan baru</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -49,8 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Menerima SMS</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -49,7 +49,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -49,7 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Menerima SMS</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -49,6 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">New message</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS ricevuto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS ricevuto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Tieni il telefono acceso e assicurati che non ci sia nulla che chiuda l\'app in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Invia ora</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS ricevuto</string>
     <string name="new_message">Nuovo messaggio</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -52,8 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">קבלת סמס</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -52,6 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -52,7 +52,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -48,6 +48,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">קבלת סמס</string>
     <string name="new_message">הודעה חדשה</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -52,7 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">קבלת סמס</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -49,8 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">受信した SMS</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -45,6 +45,13 @@
     <string name="schedule_send_warning">端末の電源を入れたままにしつつ、アプリがバックグラウンドで強制終了されないようにしてください（バッテリー節約設定からこのアプリを除外してください）。</string>
     <string name="update_message">メッセージを更新</string>
     <string name="send_now">今すぐ送信</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">受信した SMS</string>
     <string name="new_message">新しいメッセージ</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -49,7 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">受信した SMS</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -49,7 +49,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -49,6 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Gautos žinutės</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -47,6 +47,13 @@
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
     <string name="me">Aš</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Gautos žinutės</string>
     <string name="new_message">Nauja žinutė</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Gautos žinutės</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">New message</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">New message</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS ലഭിച്ചു</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">ഫോൺ ഓണാക്കി ബാക്ക്ഗ്രൗണ്ടിൽ ആയിരിക്കുമ്പോൾ ആപ്പിനെ നശിപ്പിക്കുന്ന ഒന്നും ഇല്ലെന്ന് ഉറപ്പാക്കുക.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">ഇപ്പോൾ അയയ്ക്കുക</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS ലഭിച്ചു</string>
     <string name="new_message">പുതിയ മെസ്സേജ്</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS ലഭിച്ചു</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Ha telefonen påslått og forsikre deg at appen ikke blir terminert mens den er i bakgrunnen.</string>
     <string name="update_message">Oppdater melding</string>
     <string name="send_now">Send nå</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Mottatt SMS</string>
     <string name="new_message">Ny melding</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Mottatt SMS</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Mottatt SMS</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Zorg ervoor dat het toestel blijft ingeschakeld en dat de app niet op de achtergrond wordt afgesloten.</string>
     <string name="update_message">Bericht aanpassen</string>
     <string name="send_now">Nu versturen</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Ontvangen berichten</string>
     <string name="new_message">Nieuw bericht</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Ontvangen berichten</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Ontvangen berichten</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">سنیہا بدلو</string>
     <string name="send_now">ہݨے بھیجو</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">سنیہا لیا گیا</string>
     <string name="new_message">نواں سنیہا</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">سنیہا لیا گیا</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">سنیہا لیا گیا</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -52,7 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Otrzymany SMS</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -52,8 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Otrzymany SMS</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -48,6 +48,13 @@
     <string name="schedule_send_warning">Pozostaw telefon włączony i upewnij się, że nic nie wyłącza aplikacji w tle.</string>
     <string name="update_message">Zaktualizuj wiadomość</string>
     <string name="send_now">Wyślij teraz</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Otrzymany SMS</string>
     <string name="new_message">Nowa wiadomość</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -52,6 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -52,7 +52,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Mantenha o telefone ligado e certifique-se de que não haja nada matando o aplicativo enquanto estiver em segundo plano.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Enviar agora</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recebido</string>
     <string name="new_message">Nova mensagem</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recebido</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recebido</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recebida</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Mantenha o telefone ligado e verifique se não há nada que esteja a bloquear a aplicação em segundo plano.</string>
     <string name="update_message">Atualizar mensagem</string>
     <string name="send_now">Enviar agora</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recebida</string>
     <string name="new_message">Nova mensagem</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS recebida</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS-uri primite</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS-uri primite</string>
     <string name="new_message">Mesaj nou</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS-uri primite</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -52,7 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Получено сообщение</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -52,6 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -48,6 +48,13 @@
     <string name="schedule_send_warning">Держите устройство включённым и убедитесь, что ничто не завершает принудительно приложение в фоновом режиме.</string>
     <string name="update_message">Обновить сообщение</string>
     <string name="send_now">Отправить сейчас</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Получено сообщение</string>
     <string name="new_message">Новое сообщение</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -52,7 +52,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -52,8 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Получено сообщение</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Prijatá SMS</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Majte zapnuté zariadenie a uistite sa, že apku na pozadí nič nevypne.</string>
     <string name="update_message">Upraviť správu</string>
     <string name="send_now">Odoslať teraz</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Prijatá SMS</string>
     <string name="new_message">Nová správa</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -48,11 +48,11 @@
     <string name="update_message">Upraviť správu</string>
     <string name="send_now">Odoslať teraz</string>
     <!-- Message details -->
-    <string name="message_details">Message details</string>
-    <string name="message_details_sender">Sender</string>
-    <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sent_at">Sent at</string>
-    <string name="message_details_received_at">Received at</string>
+    <string name="message_details">Detaily správy</string>
+    <string name="message_details_sender">Odosielateľ</string>
+    <string name="message_details_receiver">Prijímateľ</string>
+    <string name="message_details_sent_at">Odoslané</string>
+    <string name="message_details_received_at">Prijaté</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Prijatá SMS</string>
     <string name="new_message">Nová správa</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Prijatá SMS</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -52,8 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Prejeto SMS sporočilo</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -52,6 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -52,7 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Prejeto SMS sporočilo</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -52,7 +52,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -48,6 +48,13 @@
     <string name="schedule_send_warning">Telefon vklopite in poskrbite, da bo aplikacija v ozadju delovala.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Sedaj pošlji</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Prejeto SMS sporočilo</string>
     <string name="new_message">Novo sporočilo</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -47,6 +47,13 @@
     <string name="schedule_send_warning">Држите телефон укључен и уверите се да ништа не убија апликацију док је у позадини.</string>
     <string name="update_message">Ажурирајте поруку</string>
     <string name="send_now">Пошаљи одмах</string>
+    <!-- Message details -->
+    <string name="message_details">Детаљи о поруци</string>
+    <string name="message_details_sender">Шалје</string>
+    <string name="message_details_receiver">Прима</string>
+    <string name="message_details_type">Врста</string>
+    <string name="message_details_sent_at">Послано</string>
+    <string name="message_details_received_at">Примлјено</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Примите СМС</string>
     <string name="new_message">Нова порука</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -51,8 +51,7 @@
     <string name="message_details">Детаљи о поруци</string>
     <string name="message_details_sender">Шалје</string>
     <string name="message_details_receiver">Прима</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Послано</string>
+        <string name="message_details_sent_at">Послано</string>
     <string name="message_details_received_at">Примлјено</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Примите СМС</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -51,7 +51,7 @@
     <string name="message_details">Детаљи о поруци</string>
     <string name="message_details_sender">Шалје</string>
     <string name="message_details_receiver">Прима</string>
-        <string name="message_details_sent_at">Послано</string>
+    <string name="message_details_sent_at">Послано</string>
     <string name="message_details_received_at">Примлјено</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Примите СМС</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -51,6 +51,7 @@
     <string name="message_details">Детаљи о поруци</string>
     <string name="message_details_sender">Шалје</string>
     <string name="message_details_receiver">Прима</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Послано</string>
     <string name="message_details_received_at">Примлјено</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -51,7 +51,6 @@
     <string name="message_details">Детаљи о поруци</string>
     <string name="message_details_sender">Шалје</string>
     <string name="message_details_receiver">Прима</string>
-    <string name="message_details_type">Врста</string>
     <string name="message_details_sent_at">Послано</string>
     <string name="message_details_received_at">Примлјено</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Tog emot sms</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Ha telefonen påslagen och kontrollera att inget avslutar appen i bakgrunden.</string>
     <string name="update_message">Uppdatera meddelande</string>
     <string name="send_now">Skicka nu</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Tog emot sms</string>
     <string name="new_message">Nytt meddelande</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Tog emot sms</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS கிடைத்தது</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS கிடைத்தது</string>
     <string name="new_message">புதிய செய்தி</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS கிடைத்தது</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -49,7 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -49,7 +49,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -49,8 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -49,6 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -45,6 +45,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">New message</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Telefonu açık tutun ve arka planda uygulamayı sonlandıran hiçbir şey olmadığından emin olun.</string>
     <string name="update_message">İletiyi güncelle</string>
     <string name="send_now">Şimdi gönder</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS alındı</string>
     <string name="new_message">Yeni ileti</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS alındı</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">SMS alındı</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -48,6 +48,13 @@
     <string name="schedule_send_warning">Тримайте телефон увімкненим і переконайтеся, що ніщо не завершує застосунок у фоновому режимі.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Надіслати зараз</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Отримано повідомлення</string>
     <string name="new_message">Нове повідомлення</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -52,6 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -52,8 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Отримано повідомлення</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -52,7 +52,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -52,7 +52,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Отримано повідомлення</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -45,6 +45,13 @@
     <string name="schedule_send_warning">保持手机开机，并确保应用后台不被终止.</string>
     <string name="update_message">更新消息</string>
     <string name="send_now">立即发送</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">接收到的短信</string>
     <string name="new_message">新消息</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -49,7 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">接收到的短信</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -49,7 +49,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -49,8 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">接收到的短信</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -49,6 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -49,8 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">收到的簡訊</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -49,7 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">收到的簡訊</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -45,6 +45,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">收到的簡訊</string>
     <string name="new_message">新訊息</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -49,7 +49,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -49,6 +49,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -10,6 +10,7 @@
     <string name="mms_file_size_limit_2mb">2MB</string>
     <string name="sms">SMS</string>
     <string name="mms">MMS</string>
+    <string name="message_details_sim">SIM</string>
 
     <string name="release_62">Allow scheduling messages by long pressing the Send button</string>
     <string name="release_48">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_sim">SIM</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,6 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_type">Type</string>
     <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-        <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,13 @@
     <string name="schedule_send_warning">Keep the phone on and make sure there is nothing killing the app while in background.</string>
     <string name="update_message">Update message</string>
     <string name="send_now">Send now</string>
+    <!-- Message details -->
+    <string name="message_details">Message details</string>
+    <string name="message_details_sender">Sender</string>
+    <string name="message_details_receiver">Receiver</string>
+    <string name="message_details_type">Type</string>
+    <string name="message_details_sent_at">Sent at</string>
+    <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>
     <string name="new_message">New message</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,8 +50,7 @@
     <string name="message_details">Message details</string>
     <string name="message_details_sender">Sender</string>
     <string name="message_details_receiver">Receiver</string>
-    <string name="message_details_sim">SIM</string>
-    <string name="message_details_sent_at">Sent at</string>
+        <string name="message_details_sent_at">Sent at</string>
     <string name="message_details_received_at">Received at</string>
     <!-- Notifications -->
     <string name="channel_received_sms">Received SMS</string>


### PR DESCRIPTION
Adds a "Properties" menu button in conversation, when one message is selected, which displays details about the message:
- Type (SMS or MMS)
- Sender phone number (or receiver if it is a sent message)
- Used SIM
- Date sent at
- Date received at (if it is an incoming message)

This closes #19

## TODO

- [x] Wait for https://github.com/SimpleMobileTools/Simple-Commons/pull/1733 to be merged and update Simple-Commons ref