### PR TITLE
add asking for Exact alarm permission before scheduling 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:b4cc381943'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:57a5db1ef3'
     implementation 'org.greenrobot:eventbus:3.3.1'
     implementation 'com.github.tibbi:IndicatorFastScroll:4524cd0b61'
     implementation 'com.github.tibbi:android-smsmms:5657799572'

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/activities/MainActivity.kt
@@ -251,7 +251,10 @@ class MainActivity : SimpleActivity() {
                         handlePermission(PERMISSION_READ_CONTACTS) {
                             handleNotificationPermission { granted ->
                                 if (!granted) {
-                                    PermissionRequiredDialog(this, R.string.allow_notifications_incoming_messages)
+                                    PermissionRequiredDialog(
+                                        activity = this,
+                                        textId = R.string.allow_notifications_incoming_messages,
+                                        positiveActionCallback = { openNotificationSettings() })
                                 }
                             }
 


### PR DESCRIPTION
Add Asking for Exact alarm permission before Scheduling a message to avoid Issues caused by the exact alarm scheduling on Android 14. I also updated the Commons library version to use the new string for Alarm Permission Requests. 

This PR can be simplified by using the updates that I pushed on this PR for the Commons Library: https://github.com/SimpleMobileTools/Simple-Commons/pull/1743. If the Commons Library's PR is approved, I can update this PR to use the new Commons function and extension. 
