### PR TITLE
Remove ApnUtils usage in the app

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/App.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/App.kt
@@ -1,17 +1,11 @@
 package com.simplemobiletools.smsmessenger
 
 import android.app.Application
-import com.klinker.android.send_message.ApnUtils
 import com.simplemobiletools.commons.extensions.checkUseEnglish
-import com.simplemobiletools.commons.helpers.isRPlus
 
 class App : Application() {
     override fun onCreate() {
         super.onCreate()
         checkUseEnglish()
-
-        if (isRPlus()) {
-            ApnUtils.initDefaultApns(this) {}
-        }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/smsmessenger/receivers/MmsReceiver.kt
@@ -4,75 +4,17 @@ import android.content.Context
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
-import android.preference.PreferenceManager
-import android.provider.Telephony
 import com.bumptech.glide.Glide
 import com.klinker.android.send_message.MmsReceivedReceiver
-import com.simplemobiletools.commons.extensions.getStringValue
 import com.simplemobiletools.commons.extensions.isNumberBlocked
 import com.simplemobiletools.commons.extensions.normalizePhoneNumber
-import com.simplemobiletools.commons.extensions.queryCursor
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
-import com.simplemobiletools.commons.helpers.isQPlus
-import com.simplemobiletools.commons.helpers.isRPlus
 import com.simplemobiletools.smsmessenger.R
 import com.simplemobiletools.smsmessenger.extensions.*
 import com.simplemobiletools.smsmessenger.helpers.refreshMessages
 
 // more info at https://github.com/klinker41/android-smsmms
 class MmsReceiver : MmsReceivedReceiver() {
-
-    private var carriers = mutableMapOf<Int, MmscInformation>()
-
-    private fun populateMmscInformation(context: Context, subscriptionId: Int) {
-        if (isRPlus() && carriers.isNotEmpty()) {
-            // This information is stored by ApnUtils from android-smsmms
-            PreferenceManager.getDefaultSharedPreferences(context).apply {
-                carriers[0] = MmscInformation(
-                    getString("mmsc_url", ""),
-                    getString("mms_proxy", ""),
-                    getString("mms_port", "0")?.toInt() ?: 0
-                )
-            }
-        } else {
-            if (carriers.containsKey(subscriptionId).not()) {
-                val baseUri = if (isQPlus()) {
-                    Telephony.Carriers.SIM_APN_URI
-                } else {
-                    Telephony.Carriers.CONTENT_URI
-                }
-                val uri = Uri.withAppendedPath(baseUri, subscriptionId.toString())
-                val projection = arrayOf(
-                    Telephony.Carriers.MMSC,
-                    Telephony.Carriers.MMSPROXY,
-                    Telephony.Carriers.MMSPORT,
-                )
-                val selection = "${Telephony.Carriers.TYPE} LIKE ?"
-                val selectionArgs = arrayOf("%mms%")
-
-                context.queryCursor(uri, projection = projection, selection = selection, selectionArgs = selectionArgs) { cursor ->
-                    carriers[subscriptionId] = MmscInformation(
-                        cursor.getStringValue(Telephony.Carriers.MMSC),
-                        cursor.getStringValue(Telephony.Carriers.MMSPROXY),
-                        cursor.getStringValue(Telephony.Carriers.MMSPORT).toIntOrNull() ?: 0,
-                    )
-                }
-            }
-        }
-    }
-
-    private fun getMmscInformation(subscriptionId: Int): MmscInformation? {
-        return if (isRPlus()) {
-            carriers[0]
-        } else {
-            carriers[subscriptionId]
-        }
-    }
-
-    override fun getMmscInfoForReceptionAck(context: Context, subscriptionId: Int): MmscInformation? {
-        populateMmscInformation(context, subscriptionId)
-        return getMmscInformation(subscriptionId)
-    }
 
     override fun isAddressBlocked(context: Context, address: String): Boolean {
         val normalizedAddress = address.normalizePhoneNumber()


### PR DESCRIPTION
Using ApnUtils causes crash on newer Android versions (https://github.com/SimpleMobileTools/Simple-SMS-Messenger/pull/683#issuecomment-1637036718) This reverts this part of changes from https://github.com/SimpleMobileTools/Simple-SMS-Messenger/pull/687, since other changes have fixed the issue. This part is not as important (required to send reception ACK to MMSC, which is apparently not needed for all carriers)